### PR TITLE
Improve device table and icon handling

### DIFF
--- a/backend/core/scan.py
+++ b/backend/core/scan.py
@@ -12,15 +12,123 @@ from .notifications import notify_event
 
 
 LOGGER = logging.getLogger(__name__)
+DEFAULT_DEVICE_NAME = "Device"
+DEFAULT_DEVICE_ICONS = {"", "plus", "unknown", "device", "desktop"}
 
 
 def get_hostname(ip):
     try:
         hostname, _, _ = socket.gethostbyaddr(ip)
-        return hostname
+        return clean_hostname(hostname)
     except socket.herror as e:
         LOGGER.debug("Hostname lookup failed for %s: %s", ip, e)
-        return "Device"
+        return DEFAULT_DEVICE_NAME
+
+
+def clean_hostname(hostname):
+    hostname = (hostname or "").strip().rstrip(".")
+    if not hostname:
+        return DEFAULT_DEVICE_NAME
+    return hostname.split(".")[0].replace("-", " ").strip() or DEFAULT_DEVICE_NAME
+
+
+def short_vendor(vendor):
+    vendor = (vendor or "").strip()
+    suffixes = [
+        " incorporated",
+        " corporation",
+        " equipment",
+        " technologies",
+        " technology",
+        " co.,ltd.",
+        " co., ltd.",
+        " co ltd",
+        " ltd.",
+        " inc.",
+        " llc",
+    ]
+    changed = True
+    while changed:
+        changed = False
+        lowered = vendor.lower()
+        for suffix in suffixes:
+            if lowered.endswith(suffix):
+                vendor = vendor[: -len(suffix)].strip(" ,.-") or vendor
+                changed = True
+                break
+    return vendor
+
+
+def device_mac_suffix(mac):
+    return (mac or "").replace(":", "")[-4:].upper()
+
+
+def is_default_device_name(name):
+    cleaned = (name or "").strip().lower()
+    return not cleaned or cleaned == DEFAULT_DEVICE_NAME.lower()
+
+
+def is_default_device_icon(icon):
+    return (icon or "").strip().lower() in DEFAULT_DEVICE_ICONS
+
+
+def guess_device_icon(hostname="", vendor="", open_ports=None):
+    text = f"{hostname} {vendor}".lower()
+    open_port_numbers = {int(port["port"]) for port in open_ports or []}
+
+    if any(
+        keyword in text
+        for keyword in ("router", "gateway", "tp-link", "tplink", "ubiquiti", "mikrotik", "deco")
+    ):
+        return "router"
+    if any(keyword in text for keyword in ("iphone", "android", "phone", "mobile", "oneplus", "pixel")):
+        return "phone"
+    if any(keyword in text for keyword in ("macbook", "laptop", "notebook")):
+        return "laptop"
+    if any(keyword in text for keyword in ("apple tv", "chromecast", "streamer", "streaming", "roku", "fire tv")):
+        return "streamer"
+    if any(keyword in text for keyword in ("tv", "television")):
+        return "tv"
+    if any(keyword in text for keyword in ("camera", "cam", "hikvision", "dahua")) or 554 in open_port_numbers:
+        return "security-camera"
+    if any(keyword in text for keyword in ("shutter", "blind", "blinds", "shade", "curtain")):
+        return "shutter"
+    if any(keyword in text for keyword in ("light", "bulb", "lamp")):
+        return "light"
+    if any(keyword in text for keyword in ("air conditioner", "air-conditioning", "aircon", "hvac")):
+        return "air-conditioner"
+    if any(keyword in text for keyword in ("thermostat", "heater")):
+        return "thermostat"
+    if any(keyword in text for keyword in ("speaker", "sonos", "homepod", "audio")):
+        return "speaker"
+    if (
+        any(keyword in text for keyword in ("printer", "canon", "brother", "epson", "hewlett", "hp"))
+        or 9100 in open_port_numbers
+    ):
+        return "printer"
+    if (
+        any(keyword in text for keyword in ("server", "nas", "casaos", "raspberry", "linux"))
+        or {22, 80, 443} & open_port_numbers
+    ):
+        return "server"
+    return "unknown"
+
+
+def guess_device_name(hostname, vendor, mac):
+    if hostname and not is_default_device_name(hostname):
+        return hostname
+    if vendor:
+        vendor_name = short_vendor(vendor)
+        suffix = device_mac_suffix(mac)
+        return f"{vendor_name} device {suffix}" if suffix else f"{vendor_name} device"
+    return DEFAULT_DEVICE_NAME
+
+
+def guess_device_identity(hostname="", vendor="", mac="", open_ports=None):
+    return {
+        "name": guess_device_name(hostname, vendor, mac),
+        "icon": guess_device_icon(hostname=hostname, vendor=vendor, open_ports=open_ports),
+    }
 
 
 def get_service_name(port, protocol="tcp"):
@@ -283,6 +391,8 @@ def sync_discovered_device(element, oui=None, scan_run=None, scan_started_at=Non
     ip = element[1].psrc
     mac = element[1].hwsrc.lower()
     vendor = ManufDA.lookup(oui, mac) if oui else None
+    vendor_name = vendor[1] if vendor else ""
+    hostname = get_hostname(ip=ip)
     ports_opened = 0
     ports_closed = 0
     new_devices = 0
@@ -290,11 +400,20 @@ def sync_discovered_device(element, oui=None, scan_run=None, scan_started_at=Non
     try:
         device = Device.objects.get(mac=mac)
         was_online = device.online
+        update_fields = ["ip", "online", "lastseen", "missed_scans"]
         device.ip = ip
         device.online = True
         device.lastseen = scan_started_at
         device.missed_scans = 0
-        device.save(update_fields=["ip", "online", "lastseen", "missed_scans"])
+        if is_default_device_name(device.name) or is_default_device_icon(device.icon):
+            identity = guess_device_identity(hostname, device.vendor or vendor_name, mac)
+            if is_default_device_name(device.name):
+                device.name = identity["name"]
+                update_fields.append("name")
+            if is_default_device_icon(device.icon):
+                device.icon = identity["icon"]
+                update_fields.append("icon")
+        device.save(update_fields=update_fields)
 
         if not was_online:
             create_event(
@@ -304,12 +423,13 @@ def sync_discovered_device(element, oui=None, scan_run=None, scan_started_at=Non
                 message=f"{device.name} came online",
             )
     except Device.DoesNotExist:
+        identity = guess_device_identity(hostname, vendor_name, mac)
         device = Device.objects.create(
-            icon="plus",
-            name=get_hostname(ip=ip),
+            icon=identity["icon"],
+            name=identity["name"],
             ip=ip,
             mac=mac,
-            vendor=vendor[1] if vendor else "",
+            vendor=vendor_name,
             lastseen=scan_started_at,
         )
         new_devices = 1
@@ -332,7 +452,15 @@ def sync_discovered_device(element, oui=None, scan_run=None, scan_started_at=Non
         )
 
     if should_scan_ports(device, now=scan_started_at):
-        port_stats = sync_device_ports(device, scan_open_ports(ip), scan_run=scan_run)
+        open_ports = scan_open_ports(ip)
+        if is_default_device_icon(device.icon):
+            device.icon = guess_device_icon(
+                hostname=device.name,
+                vendor=device.vendor,
+                open_ports=open_ports,
+            )
+            device.save(update_fields=["icon"])
+        port_stats = sync_device_ports(device, open_ports, scan_run=scan_run)
         ports_opened += port_stats["ports_opened"]
         ports_closed += port_stats["ports_closed"]
         device.last_port_scan = scan_started_at

--- a/backend/core/tests.py
+++ b/backend/core/tests.py
@@ -16,6 +16,7 @@ from .notifications import notify_event, retry_failed_notifications
 from .scan import (
     create_event,
     discover_devices,
+    guess_device_identity,
     mark_missing_devices_offline,
     normalize_scan_ports,
     sync_discovered_device,
@@ -194,6 +195,59 @@ class ScanStabilityTests(TestCase):
         scan_open_ports.assert_called_once_with(device.ip)
         device.refresh_from_db()
         self.assertIsNotNone(device.last_port_scan)
+
+    def test_guess_device_identity_uses_hostname_before_vendor(self):
+        identity = guess_device_identity(
+            hostname="apple-tv-livingroom",
+            vendor="Apple, Inc.",
+            mac="aa:bb:cc:dd:ee:ff",
+        )
+
+        self.assertEqual(identity["name"], "apple-tv-livingroom")
+        self.assertEqual(identity["icon"], "streamer")
+
+    def test_guess_device_identity_uses_vendor_fallback_name(self):
+        identity = guess_device_identity(
+            hostname="Device",
+            vendor="TP-Link Technologies Co., Ltd.",
+            mac="aa:bb:cc:dd:ee:ff",
+        )
+
+        self.assertEqual(identity["name"], "TP-Link device EEFF")
+        self.assertEqual(identity["icon"], "router")
+
+    @override_settings(PORT_SCAN_ENABLED=False)
+    @patch("core.scan.get_hostname")
+    def test_new_discovered_device_gets_guessed_name_and_icon(self, get_hostname):
+        get_hostname.return_value = "livingroom-camera"
+
+        sync_discovered_device(
+            self.scan_element("192.168.1.25", "aa:bb:cc:dd:ee:ff"),
+            oui=None,
+            scan_run=ScanRun.objects.create(ip_range="192.168.1.0/24"),
+        )
+
+        device = Device.objects.get(mac="aa:bb:cc:dd:ee:ff")
+        self.assertEqual(device.name, "livingroom-camera")
+        self.assertEqual(device.icon, "security-camera")
+
+    def test_guess_device_identity_detects_shutter(self):
+        identity = guess_device_identity(
+            hostname="bedroom-shutter",
+            vendor="Aqara",
+            mac="aa:bb:cc:dd:ee:ff",
+        )
+
+        self.assertEqual(identity["icon"], "shutter")
+
+    def test_guess_device_identity_detects_air_conditioner(self):
+        identity = guess_device_identity(
+            hostname="bedroom-air-conditioner",
+            vendor="GD Midea Air-Conditioning Equipment Co.,Ltd.",
+            mac="aa:bb:cc:dd:ee:ff",
+        )
+
+        self.assertEqual(identity["icon"], "air-conditioner")
 
 
 class NotificationTests(TestCase):
@@ -475,6 +529,46 @@ class ScanApiTests(TestCase):
         self.assertEqual(response.data["pagination"]["limit"], 2)
         self.assertEqual(response.data["pagination"]["offset"], 0)
         self.assertEqual(response.data["pagination"]["next_offset"], 2)
+
+    def test_device_endpoint_sorts_by_name(self):
+        Device.objects.create(
+            name="Access point",
+            ip="192.168.1.30",
+            mac="bb:bb:bb:bb:bb:bb",
+        )
+        Device.objects.create(
+            name="Camera",
+            ip="192.168.1.40",
+            mac="cc:cc:cc:cc:cc:cc",
+        )
+
+        response = self.client.get("/api/v1/device/", {"ordering": "name"})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            [device["name"] for device in response.data["data"]],
+            ["Access point", "Camera", "Laptop"],
+        )
+
+    def test_device_endpoint_sorts_by_ip_naturally(self):
+        Device.objects.create(
+            name="Low IP",
+            ip="192.168.1.2",
+            mac="bb:bb:bb:bb:bb:bb",
+        )
+        Device.objects.create(
+            name="High IP",
+            ip="192.168.1.100",
+            mac="cc:cc:cc:cc:cc:cc",
+        )
+
+        response = self.client.get("/api/v1/device/", {"ordering": "ip"})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            [device["ip"] for device in response.data["data"]],
+            ["192.168.1.2", "192.168.1.20", "192.168.1.100"],
+        )
 
     def test_device_endpoint_counters_include_current_open_ports(self):
         DevicePort.objects.create(device=self.device, port=80, protocol="tcp", open=True)

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -1,3 +1,5 @@
+import ipaddress
+
 from drf_spectacular.utils import OpenApiTypes, extend_schema, inline_serializer
 from rest_framework import status, generics, permissions
 from rest_framework import serializers
@@ -34,6 +36,59 @@ from .api import (
 from .scan import scan, validate_ip_range
 
 LOGGER = logging.getLogger(__name__)
+
+
+DEVICE_ORDERING_FIELDS = {
+    "name": ("name", "ip", "id"),
+    "-name": ("-name", "ip", "id"),
+}
+
+
+def ip_sort_key(device):
+    try:
+        address = ipaddress.ip_address(device.ip)
+    except ValueError:
+        return (1, device.ip, device.name.lower(), device.id)
+    return (0, address.version, int(address), device.name.lower(), device.id)
+
+
+def paginated_device_payload(request, devices):
+    ordering = request.query_params.get("ordering")
+    if ordering in DEVICE_ORDERING_FIELDS:
+        devices = devices.order_by(*DEVICE_ORDERING_FIELDS[ordering])
+        return paginated_payload(
+            request,
+            devices,
+            DeviceSerializer,
+            default_limit=10,
+            max_limit=100,
+        )
+    if ordering in {"ip", "-ip"}:
+        limit = parse_int_param(request.query_params, "limit", default=10, minimum=1, maximum=100)
+        offset = parse_int_param(request.query_params, "offset", default=0, minimum=0)
+        sorted_devices = sorted(devices, key=ip_sort_key, reverse=ordering == "-ip")
+        total = len(sorted_devices)
+        next_offset = offset + limit if offset + limit < total else None
+        previous_offset = max(offset - limit, 0) if offset > 0 else None
+        return {
+            "data": DeviceSerializer(sorted_devices[offset : offset + limit], many=True).data,
+            "pagination": {
+                "count": total,
+                "limit": limit,
+                "offset": offset,
+                "next_offset": next_offset,
+                "previous_offset": previous_offset,
+            },
+        }
+    if ordering:
+        raise ValidationError({"ordering": "Must be one of: name, -name, ip, -ip."})
+    return paginated_payload(
+        request,
+        devices,
+        DeviceSerializer,
+        default_limit=10,
+        max_limit=100,
+    )
 
 
 @permission_classes([AllowAny])
@@ -184,13 +239,7 @@ def device(request):
                 )
                 devices = devices.filter(ports__port=port, ports__open=True).distinct()
 
-            payload = paginated_payload(
-                request,
-                devices,
-                DeviceSerializer,
-                default_limit=10,
-                max_limit=100,
-            )
+            payload = paginated_device_payload(request, devices)
             return Response(
                 {
                     "data": payload["data"],

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -121,6 +121,13 @@ textarea {
   justify-content: center;
 }
 
+.device-table-icon {
+  align-items: center;
+  color: #4c6ef5;
+  display: inline-flex;
+  flex: 0 0 auto;
+}
+
 .ports-list {
   align-items: center;
   display: flex;
@@ -139,6 +146,98 @@ textarea {
 
 .port-overflow-badge {
   min-width: 40px;
+}
+
+.sortable-header {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  cursor: pointer;
+  display: inline-flex;
+  font: inherit;
+  font-weight: 700;
+  gap: 6px;
+  padding: 0;
+}
+
+.sortable-header:hover,
+.sortable-header.active {
+  color: #3b5bdb;
+}
+
+.sort-icon {
+  color: #9aa4b2;
+  transition: color 120ms ease, transform 120ms ease;
+}
+
+.sortable-header.active .sort-icon {
+  color: #3b5bdb;
+}
+
+.sort-icon.desc {
+  transform: rotate(180deg);
+}
+
+.device-field {
+  background: #f8faff;
+  border: 1px solid #dfe5ef;
+  border-radius: 8px;
+  min-width: 0;
+  padding: 10px 12px;
+}
+
+.device-field.editable {
+  background: #fff;
+}
+
+.device-field-input {
+  background: transparent;
+  border: 0;
+  color: #1f2937;
+  display: block;
+  font: inherit;
+  margin-top: 4px;
+  outline: 0;
+  padding: 0;
+  width: 100%;
+}
+
+.icon-picker-field {
+  grid-column: 1 / -1;
+}
+
+.icon-picker-grid {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(auto-fill, minmax(46px, 1fr));
+  margin-top: 8px;
+}
+
+.icon-picker-button {
+  align-items: center;
+  aspect-ratio: 1;
+  background: #fff;
+  border: 1px solid #dfe5ef;
+  border-radius: 8px;
+  color: #4b5563;
+  cursor: pointer;
+  display: inline-flex;
+  justify-content: center;
+  min-height: 46px;
+  min-width: 0;
+}
+
+.icon-picker-button:hover,
+.icon-picker-button.selected {
+  background: #eef3ff;
+  border-color: #4c6ef5;
+  color: #3b5bdb;
+}
+
+.wrap-text {
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .truncate-cell {

--- a/frontend/app/page.jsx
+++ b/frontend/app/page.jsx
@@ -31,16 +31,31 @@ import {
 import { useDisclosure } from '@mantine/hooks';
 import {
   IconAlertCircle,
+  IconAirConditioning,
+  IconArrowsSort,
   IconBell,
+  IconBlind,
+  IconBulb,
+  IconCast,
   IconClock,
+  IconDeviceCctv,
   IconDeviceDesktop,
+  IconDeviceLaptop,
+  IconDeviceMobile,
+  IconDeviceSpeaker,
+  IconDeviceTv,
   IconHistory,
   IconLogout,
   IconNetwork,
   IconPlugConnected,
+  IconPrinter,
+  IconQuestionMark,
   IconRefresh,
+  IconRouter,
   IconSearch,
+  IconServer,
   IconShieldCheck,
+  IconTemperature,
   IconTrash,
   IconUserPlus,
   IconWifi,
@@ -68,6 +83,99 @@ const deviceStatusOptions = [
   { value: 'offline', label: 'Offline' },
   { value: 'new', label: 'New devices' },
 ];
+
+const deviceIconOptions = [
+  { value: 'unknown', label: 'Unknown', icon: IconQuestionMark },
+  { value: 'desktop', label: 'Desktop', icon: IconDeviceDesktop },
+  { value: 'router', label: 'Router', icon: IconRouter },
+  { value: 'phone', label: 'Phone', icon: IconDeviceMobile },
+  { value: 'laptop', label: 'Laptop', icon: IconDeviceLaptop },
+  { value: 'tv', label: 'TV', icon: IconDeviceTv },
+  { value: 'streamer', label: 'Streamer', icon: IconCast },
+  { value: 'security-camera', label: 'Security camera', icon: IconDeviceCctv },
+  { value: 'shutter', label: 'Shutter', icon: IconBlind },
+  { value: 'light', label: 'Light', icon: IconBulb },
+  { value: 'air-conditioner', label: 'Air conditioner', icon: IconAirConditioning },
+  { value: 'thermostat', label: 'Thermostat', icon: IconTemperature },
+  { value: 'speaker', label: 'Speaker', icon: IconDeviceSpeaker },
+  { value: 'printer', label: 'Printer', icon: IconPrinter },
+  { value: 'server', label: 'Server', icon: IconServer },
+];
+
+function normalizeDeviceIcon(value) {
+  const aliases = {
+    plus: 'unknown',
+    device: 'desktop',
+    computer: 'desktop',
+    mobile: 'phone',
+    television: 'tv',
+    cast: 'streamer',
+    streaming: 'streamer',
+    camera: 'security-camera',
+    cctv: 'security-camera',
+    blind: 'shutter',
+    blinds: 'shutter',
+    shade: 'shutter',
+    curtain: 'shutter',
+    bulb: 'light',
+    aircon: 'air-conditioner',
+    ac: 'air-conditioner',
+    hvac: 'air-conditioner',
+    'thermometer-snow': 'thermostat',
+    temperature: 'thermostat',
+    audio: 'speaker',
+    nas: 'server',
+  };
+  const normalized = aliases[value] || value || 'unknown';
+  return deviceIconOptions.some((option) => option.value === normalized)
+    ? normalized
+    : 'unknown';
+}
+
+function DeviceIcon({ value, size = 18 }) {
+  const normalized = normalizeDeviceIcon(value);
+  const option =
+    deviceIconOptions.find((item) => item.value === normalized) ||
+    deviceIconOptions[0];
+  const Icon = option.icon;
+  return <Icon size={size} stroke={1.8} />;
+}
+
+function sortableOrdering(field, currentOrdering) {
+  if (currentOrdering === field) {
+    return `-${field}`;
+  }
+  if (currentOrdering === `-${field}`) {
+    return '';
+  }
+  return field;
+}
+
+function SortableHeader({ field, label, ordering, onChange, className }) {
+  const active = ordering === field || ordering === `-${field}`;
+  const direction = ordering === field ? 'asc' : ordering === `-${field}` ? 'desc' : '';
+  const title = active
+    ? `${label} sorted ${direction === 'asc' ? 'ascending' : 'descending'}`
+    : `Sort by ${label}`;
+
+  return (
+    <Table.Th className={className}>
+      <button
+        type="button"
+        className={`sortable-header ${active ? 'active' : ''}`}
+        onClick={() => onChange(sortableOrdering(field, ordering))}
+        aria-label={title}
+      >
+        <span>{label}</span>
+        <IconArrowsSort
+          size={15}
+          stroke={1.9}
+          className={direction ? `sort-icon ${direction}` : 'sort-icon'}
+        />
+      </button>
+    </Table.Th>
+  );
+}
 
 function formatDate(value) {
   if (!value) {
@@ -253,14 +361,66 @@ function PortSummary({ ports = [] }) {
   );
 }
 
+function DeviceField({ label, value, editable = false, required = false, onChange }) {
+  return (
+    <Box className={`device-field ${editable ? 'editable' : ''}`}>
+      <Group gap={4}>
+        <Text size="xs" c="dimmed">{label}</Text>
+        {required && <Text size="xs" c="red">*</Text>}
+      </Group>
+      {editable ? (
+        <input
+          className="device-field-input"
+          value={value}
+          onChange={(event) => onChange(event.currentTarget.value)}
+        />
+      ) : (
+        <Text size="sm" className="wrap-text">{value || '-'}</Text>
+      )}
+    </Box>
+  );
+}
+
+function DeviceIconPicker({ value, onChange }) {
+  const selectedIcon = normalizeDeviceIcon(value);
+
+  return (
+    <Box className="device-field icon-picker-field">
+      <Text size="xs" c="dimmed">Icon</Text>
+      <div className="icon-picker-grid">
+        {deviceIconOptions.map((option) => {
+          const Icon = option.icon;
+          const selected = option.value === selectedIcon;
+
+          return (
+            <Tooltip key={option.value} label={option.label}>
+              <button
+                type="button"
+                className={`icon-picker-button ${selected ? 'selected' : ''}`}
+                onClick={() => onChange(option.value)}
+                aria-label={option.label}
+              >
+                <Icon size={18} stroke={1.8} />
+              </button>
+            </Tooltip>
+          );
+        })}
+      </div>
+    </Box>
+  );
+}
+
 function DeviceModal({ device, opened, onClose, onSaved }) {
+  const [icon, setIcon] = useState('');
   const [name, setName] = useState('');
   const [known, setKnown] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
+  const [deleteConfirmOpened, deleteConfirm] = useDisclosure(false);
 
   useEffect(() => {
     if (device) {
+      setIcon(device.icon || '');
       setName(device.name || '');
       setKnown(Boolean(device.known));
       setError('');
@@ -276,7 +436,11 @@ function DeviceModal({ device, opened, onClose, onSaved }) {
     try {
       await apiRequest(`device/?id=${device.id}`, {
         method: 'PUT',
-        body: { name, known },
+        body: {
+          icon,
+          name,
+          known,
+        },
       });
       await onSaved();
       onClose();
@@ -296,6 +460,7 @@ function DeviceModal({ device, opened, onClose, onSaved }) {
     try {
       await apiRequest(`device/?id=${device.id}`, { method: 'DELETE' });
       await onSaved();
+      deleteConfirm.close();
       onClose();
     } catch (err) {
       setError(err.message);
@@ -304,19 +469,102 @@ function DeviceModal({ device, opened, onClose, onSaved }) {
     }
   }
 
+  function closeModal() {
+    deleteConfirm.close();
+    onClose();
+  }
+
   return (
-    <Modal opened={opened} onClose={onClose} title={device?.name} centered>
+    <Modal
+      opened={opened}
+      onClose={closeModal}
+      title={device?.name || 'Device'}
+      centered
+      size="lg"
+    >
       <Stack>
         {error && (
           <Alert color="red" icon={<IconAlertCircle size={18} />}>
             {error}
           </Alert>
         )}
-        <TextInput label="Name" value={name} onChange={(e) => setName(e.currentTarget.value)} />
-        <Switch label="Known device" checked={known} onChange={(e) => setKnown(e.currentTarget.checked)} />
+
+        <SimpleGrid cols={{ base: 1, sm: 2 }}>
+          <DeviceField
+            label="Name"
+            value={name}
+            editable
+            required
+            onChange={setName}
+          />
+          <DeviceField
+            label="Vendor"
+            value={device?.vendor || '-'}
+          />
+          <DeviceField
+            label="IP address"
+            value={device?.ip || '-'}
+          />
+          <DeviceField
+            label="MAC address"
+            value={device?.mac || '-'}
+          />
+          <DeviceIconPicker value={icon} onChange={setIcon} />
+        </SimpleGrid>
+
+        <Group>
+          <Switch
+            label="Known device"
+            checked={known}
+            onChange={(event) => setKnown(event.currentTarget.checked)}
+          />
+          <Group gap="xs">
+            <span className={`status-dot ${device?.online ? 'online' : 'offline'}`} />
+            <Text size="sm">{device?.online ? 'Online' : 'Offline'}</Text>
+            <Text size="sm" c="dimmed">Missed scans: {device?.missed_scans ?? 0}</Text>
+          </Group>
+        </Group>
+
+        <Divider />
+
+        <SimpleGrid cols={{ base: 1, sm: 2 }}>
+          <Box>
+            <Text size="xs" c="dimmed">First seen</Text>
+            <Text size="sm">{formatDate(device?.firstseen)}</Text>
+          </Box>
+          <Box>
+            <Text size="xs" c="dimmed">Last seen</Text>
+            <Text size="sm">{formatDate(device?.lastseen)}</Text>
+          </Box>
+          <Box>
+            <Text size="xs" c="dimmed">Last port scan</Text>
+            <Text size="sm">{formatDate(device?.last_port_scan)}</Text>
+          </Box>
+          <Box>
+            <Text size="xs" c="dimmed">Open ports</Text>
+            <Group gap={4} mt={4}>
+              {(device?.open_ports || []).length ? (
+                (device?.open_ports || []).map((port) => (
+                  <Badge key={`${port.protocol}-${port.port}`} variant="light">
+                    {port.protocol}/{port.port}
+                  </Badge>
+                ))
+              ) : (
+                <Text size="sm">-</Text>
+              )}
+            </Group>
+          </Box>
+        </SimpleGrid>
+
         <Divider />
         <Group justify="space-between">
-          <Button color="red" variant="light" leftSection={<IconTrash size={18} />} onClick={remove} loading={saving}>
+          <Button
+            color="red"
+            variant="light"
+            leftSection={<IconTrash size={18} />}
+            onClick={deleteConfirm.open}
+            loading={saving}
+          >
             Delete
           </Button>
           <Button onClick={save} loading={saving}>
@@ -324,6 +572,32 @@ function DeviceModal({ device, opened, onClose, onSaved }) {
           </Button>
         </Group>
       </Stack>
+      <Modal
+        opened={deleteConfirmOpened}
+        onClose={deleteConfirm.close}
+        title="Delete device"
+        centered
+      >
+        <Stack>
+          <Text>Are you sure you want to delete this device?</Text>
+          <Text size="sm" c="dimmed">
+            {device?.name} will be removed from the inventory.
+          </Text>
+          <Group justify="flex-end">
+            <Button variant="default" onClick={deleteConfirm.close}>
+              Cancel
+            </Button>
+            <Button
+              color="red"
+              leftSection={<IconTrash size={18} />}
+              onClick={remove}
+              loading={saving}
+            >
+              Delete
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
     </Modal>
   );
 }
@@ -349,6 +623,8 @@ function Dashboard({ user, onLogout }) {
   const [deviceStatus, setDeviceStatus] = useState('');
   const [devicePage, setDevicePage] = useState(1);
   const [devicePageSize, setDevicePageSize] = useState('10');
+  const [deviceOrdering, setDeviceOrdering] = useState('');
+  const [activeTab, setActiveTab] = useState('events');
   const [eventType, setEventType] = useState('');
   const [scanRange, setScanRange] = useState('');
   const [activeDevice, setActiveDevice] = useState(null);
@@ -360,6 +636,7 @@ function Dashboard({ user, onLogout }) {
     eventType: '',
     deviceLimit: 10,
     deviceOffset: 0,
+    deviceOrdering: '',
   });
 
   const filteredDevices = useMemo(() => devices, [devices]);
@@ -381,8 +658,9 @@ function Dashboard({ user, onLogout }) {
       eventType,
       deviceLimit,
       deviceOffset,
+      deviceOrdering,
     };
-  }, [search, deviceStatus, eventType, deviceLimit, deviceOffset]);
+  }, [search, deviceStatus, eventType, deviceLimit, deviceOffset, deviceOrdering]);
 
   async function loadData({ quiet = false } = {}) {
     if (quiet) {
@@ -405,10 +683,11 @@ function Dashboard({ user, onLogout }) {
         known: currentTableState.deviceStatus === 'new' ? 'false' : undefined,
         limit: currentTableState.deviceLimit,
         offset: currentTableState.deviceOffset,
+        ordering: currentTableState.deviceOrdering || undefined,
       };
       const eventParams = {
         event_type: currentTableState.eventType || undefined,
-        limit: 12,
+        limit: 8,
       };
 
       const [deviceData, statusData, runData, eventData, notificationData] =
@@ -456,11 +735,11 @@ function Dashboard({ user, onLogout }) {
   useEffect(() => {
     const timer = window.setTimeout(() => loadData({ quiet: true }), 250);
     return () => window.clearTimeout(timer);
-  }, [search, deviceStatus, eventType, devicePage, devicePageSize]);
+  }, [search, deviceStatus, eventType, devicePage, devicePageSize, deviceOrdering]);
 
   useEffect(() => {
     setDevicePage(1);
-  }, [search, deviceStatus, devicePageSize]);
+  }, [search, deviceStatus, devicePageSize, deviceOrdering]);
 
   async function runScan() {
     setRefreshing(true);
@@ -567,8 +846,20 @@ function Dashboard({ user, onLogout }) {
                       <Table.Thead>
                         <Table.Tr>
                           <Table.Th className="device-status-cell">Status</Table.Th>
-                          <Table.Th className="device-name-cell">Name</Table.Th>
-                          <Table.Th className="device-ip-cell">IP</Table.Th>
+                          <SortableHeader
+                            field="name"
+                            label="Name"
+                            ordering={deviceOrdering}
+                            onChange={setDeviceOrdering}
+                            className="device-name-cell"
+                          />
+                          <SortableHeader
+                            field="ip"
+                            label="IP"
+                            ordering={deviceOrdering}
+                            onChange={setDeviceOrdering}
+                            className="device-ip-cell"
+                          />
                           <Table.Th className="device-mac-cell">MAC</Table.Th>
                           <Table.Th className="device-ports-cell">Ports</Table.Th>
                           <Table.Th className="device-lastseen-cell">Last seen</Table.Th>
@@ -593,9 +884,14 @@ function Dashboard({ user, onLogout }) {
                               </Group>
                             </Table.Td>
                             <Table.Td className="device-name-cell" fw={600}>
-                              <span className="truncate-cell" title={device.name}>
-                                {device.name}
-                              </span>
+                              <Group gap="xs" wrap="nowrap">
+                                <span className="device-table-icon">
+                                  <DeviceIcon value={device.icon} size={17} />
+                                </span>
+                                <span className="truncate-cell" title={device.name}>
+                                  {device.name}
+                                </span>
+                              </Group>
                             </Table.Td>
                             <Table.Td className="device-ip-cell">{device.ip}</Table.Td>
                             <Table.Td className="device-mac-cell">{device.mac}</Table.Td>
@@ -668,31 +964,55 @@ function Dashboard({ user, onLogout }) {
             </Paper>
           </SimpleGrid>
 
-          <Tabs defaultValue="events">
-            <Tabs.List>
-              <Tabs.Tab value="events" leftSection={<IconBell size={16} />}>Events</Tabs.Tab>
-              <Tabs.Tab value="history" leftSection={<IconHistory size={16} />}>Scan history</Tabs.Tab>
-              <Tabs.Tab value="notifications" leftSection={<IconBell size={16} />}>Notifications</Tabs.Tab>
-            </Tabs.List>
+          <Tabs value={activeTab} onChange={(value) => setActiveTab(value || 'events')}>
+            <Group justify="space-between" align="flex-end">
+              <Tabs.List>
+                <Tabs.Tab value="events" leftSection={<IconBell size={16} />}>Events</Tabs.Tab>
+                <Tabs.Tab value="history" leftSection={<IconHistory size={16} />}>Scan history</Tabs.Tab>
+                <Tabs.Tab value="notifications" leftSection={<IconBell size={16} />}>Notifications</Tabs.Tab>
+              </Tabs.List>
+              {activeTab === 'events' && (
+                <Select
+                  w={210}
+                  placeholder="Event type"
+                  clearable
+                  data={eventTypeOptions}
+                  value={eventType}
+                  onChange={(value) => setEventType(value || '')}
+                />
+              )}
+            </Group>
 
             <Tabs.Panel value="events" pt="md">
-              <Paper className="content-panel" radius="md" p="md">
-                <Group justify="space-between" mb="md">
-                  <Title order={4}>Network events</Title>
-                  <Select
-                    w={210}
-                    placeholder="Event type"
-                    clearable
-                    data={eventTypeOptions}
-                    value={eventType}
-                    onChange={(value) => setEventType(value || '')}
-                  />
-                </Group>
-                <Stack gap="xs">
-                  {events.map((event) => (
-                    <EventItem key={event.id} event={event} />
-                  ))}
-                </Stack>
+              <Paper className="content-panel" radius="md">
+                <Table verticalSpacing="sm">
+                  <Table.Thead>
+                    <Table.Tr>
+                      <Table.Th>Type</Table.Th>
+                      <Table.Th>Message</Table.Th>
+                      <Table.Th>Created</Table.Th>
+                      <Table.Th>Status</Table.Th>
+                    </Table.Tr>
+                  </Table.Thead>
+                  <Table.Tbody>
+                    {events.map((event) => (
+                      <Table.Tr key={event.id}>
+                        <Table.Td>
+                          <Badge variant="light">
+                            {event.event_type_display || event.event_type}
+                          </Badge>
+                        </Table.Td>
+                        <Table.Td>{event.message}</Table.Td>
+                        <Table.Td>{formatDate(event.created_at)}</Table.Td>
+                        <Table.Td>
+                          <Badge color={event.notified ? 'teal' : 'gray'} variant="light">
+                            {event.notified ? 'Handled' : 'Pending'}
+                          </Badge>
+                        </Table.Td>
+                      </Table.Tr>
+                    ))}
+                  </Table.Tbody>
+                </Table>
               </Paper>
             </Tabs.Panel>
 
@@ -792,24 +1112,6 @@ function NumberReadout({ label, value }) {
         {value ?? 0}
       </Text>
     </Box>
-  );
-}
-
-function EventItem({ event }) {
-  return (
-    <Paper withBorder radius="md" p="sm">
-      <Group justify="space-between" align="flex-start">
-        <Box>
-          <Text fw={600}>{event.message}</Text>
-          <Text size="xs" c="dimmed">
-            {event.event_type_display || event.event_type} · {formatDate(event.created_at)}
-          </Text>
-        </Box>
-        <Badge color={event.notified ? 'teal' : 'gray'} variant="light">
-          {event.notified ? 'Notified' : 'Pending'}
-        </Badge>
-      </Group>
-    </Paper>
   );
 }
 


### PR DESCRIPTION
## Summary
- Add device table sorting by name and natural IP ordering.
- Add Tabler-only device icon options for streamer, shutter, air conditioner, and security camera.
- Improve device modal layout for missed scans and expanded icon picker.
- Add backend device icon guessing and API sorting coverage.

## Validation
- npm run lint
- npm run build
- python3 -m py_compile backend/core/scan.py backend/core/views.py backend/core/tests.py
- git diff --check

Note: the full Django test suite could not run locally because the existing .venv points to a missing Python 3.11 binary.