### PR TITLE
Release 1.0.1 startup lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,19 @@
 # LanGuard
 
-![LanGuard logo](frontend/public/logo.png)
+<p align="center">
+  <img src="frontend/public/logo.png" alt="LanGuard logo" width="120">
+</p>
+
+<p align="center">
+  <img alt="Version" src="https://img.shields.io/badge/version-1.0.1-blue">
+  <img alt="Release downloads" src="https://img.shields.io/github/downloads/hillaliy/LanGuard/total?label=downloads">
+  <a href="https://github.com/hillaliy/LanGuard/pkgs/container/languard-backend">
+    <img alt="Backend image" src="https://img.shields.io/badge/GHCR-backend-2ea44f">
+  </a>
+  <a href="https://github.com/hillaliy/LanGuard/pkgs/container/languard-frontend">
+    <img alt="Frontend image" src="https://img.shields.io/badge/GHCR-frontend-2ea44f">
+  </a>
+</p>
 
 LanGuard is a self-hosted LAN visibility tool for home networks. It finds devices, tracks online/offline state, scans common ports, keeps history, and can send Discord or Telegram alerts for new devices.
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,26 @@
 #!/bin/sh
 set -e
 
+LOCK_DIR="${MIGRATION_LOCK_DIR:-/data/.startup-lock}"
+mkdir -p "$(dirname "$LOCK_DIR")"
+
+cleanup_lock() {
+    rmdir "$LOCK_DIR" 2>/dev/null || true
+}
+
+while ! mkdir "$LOCK_DIR" 2>/dev/null; do
+    echo "Waiting for another LanGuard container to finish startup migrations..."
+    sleep 2
+done
+
+trap cleanup_lock EXIT INT TERM
+
 python manage.py migrate --fake-initial --no-input
 python manage.py collectstatic --no-input
 python manage.py createcachetable || true
+
+cleanup_lock
+trap - EXIT INT TERM
 
 if [ "$#" -gt 0 ]; then
     exec "$@"

--- a/frontend/app/version.js
+++ b/frontend/app/version.js
@@ -4,6 +4,14 @@ export const APP_VERSION = packageInfo.version;
 
 export const CHANGELOG_ENTRIES = [
   {
+    version: '1.0.1',
+    date: '2026-06-29',
+    items: [
+      'Added a container startup lock so backend and scanner migrations do not race on first deploy.',
+      'Improved README logo sizing and project badges.',
+    ],
+  },
+  {
     version: '1.0.0',
     date: '2026-06-29',
     items: [

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "languard-frontend",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "languard-frontend",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "engines": {
         "node": ">=24"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "languard-frontend",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

- Bump LanGuard frontend/app version to 1.0.1.
- Add a shared startup lock in `entrypoint.sh` so backend and scanner containers do not race while running migrations against the same SQLite database.
- Shrink the README logo and add project/package badges.

## Validation

- `sh -n entrypoint.sh`
- `npm run lint`
- `npm run build`
- `git diff --check`