### PR TITLE
Release 1.0.2 host network scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 <p align="center">
-  <img alt="Version" src="https://img.shields.io/badge/version-1.0.1-blue">
+  <img alt="Version" src="https://img.shields.io/badge/version-1.0.2-blue">
   <img alt="Release downloads" src="https://img.shields.io/github/downloads/hillaliy/LanGuard/total?label=downloads">
   <a href="https://github.com/hillaliy/LanGuard/pkgs/container/languard-backend">
     <img alt="Backend image" src="https://img.shields.io/badge/GHCR-backend-2ea44f">
@@ -36,6 +36,7 @@ services:
     image: ghcr.io/hillaliy/languard-backend:latest
     container_name: languard-backend
     privileged: true
+    network_mode: host
     environment:
       - SECRET_KEY=change-this-to-a-long-random-secret
       - ALLOWED_HOSTS=192.168.1.10,languard.local
@@ -48,7 +49,8 @@ services:
     image: ghcr.io/hillaliy/languard-backend:latest
     container_name: languard-scanner
     privileged: true
-    command: ["python", "manage.py", "run_scheduler"]
+    network_mode: host
+    command: ["python", "-u", "manage.py", "run_scheduler", "--run-now"]
     environment:
       - SECRET_KEY=change-this-to-a-long-random-secret
       - ALLOWED_HOSTS=192.168.1.10,languard.local
@@ -62,6 +64,10 @@ services:
   frontend:
     image: ghcr.io/hillaliy/languard-frontend:latest
     container_name: languard-frontend
+    environment:
+      - BACKEND_UPSTREAM=host.docker.internal:8000
+    extra_hosts:
+      - host.docker.internal:host-gateway
     ports:
       - 8080:80
     restart: unless-stopped
@@ -97,6 +103,8 @@ Open `http://<docker-host-ip>:8080` and create the first user. That user becomes
 After sign in, open Settings to change the scan range, scan interval, timezone, Discord webhook, or Telegram settings.
 
 Portainer will create the stack network automatically.
+
+Backend and scanner use host networking so ARP discovery can see LAN devices. Without host networking, Docker bridge networking may only show the Docker host/gateway.
 
 ## Update
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,8 +10,7 @@ services:
       STATIC_ROOT: /static
     build:
       context: .
-    ports:
-      - '8000:8000'
+    network_mode: host
     privileged: true
   scanner:
     volumes:
@@ -24,13 +23,18 @@ services:
       STATIC_ROOT: /static
     build:
       context: .
-    command: ["python", "manage.py", "run_scheduler"]
+    command: ["python", "-u", "manage.py", "run_scheduler", "--run-now"]
+    network_mode: host
     privileged: true
     depends_on:
       - backend
   frontend:
     build:
       context: ./frontend
+    environment:
+      BACKEND_UPSTREAM: host.docker.internal:8000
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     ports:
       - '8080:80'
     depends_on:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,7 +23,17 @@ cleanup_lock
 trap - EXIT INT TERM
 
 if [ "$#" -gt 0 ]; then
+    echo "Starting command: $*"
     exec "$@"
 fi
 
-exec granian --interface wsgi --host 0.0.0.0 --port 8000 backend.wsgi:application
+echo "Starting backend web server..."
+exec granian \
+    --interface wsgi \
+    --host 0.0.0.0 \
+    --port 8000 \
+    --workers "${GRANIAN_WORKERS:-1}" \
+    --blocking-threads "${GRANIAN_BLOCKING_THREADS:-4}" \
+    --backpressure "${GRANIAN_BACKPRESSURE:-32}" \
+    --no-ws \
+    backend.wsgi:application

--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -2,19 +2,19 @@
     encode zstd gzip
 
     handle /api/v1/* {
-        reverse_proxy backend:8000
+        reverse_proxy {$BACKEND_UPSTREAM:backend:8000}
     }
 
     handle /api/schema/* {
-        reverse_proxy backend:8000
+        reverse_proxy {$BACKEND_UPSTREAM:backend:8000}
     }
 
     handle /admin* {
-        reverse_proxy backend:8000
+        reverse_proxy {$BACKEND_UPSTREAM:backend:8000}
     }
 
     handle /static/* {
-        reverse_proxy backend:8000
+        reverse_proxy {$BACKEND_UPSTREAM:backend:8000}
     }
 
     handle {

--- a/frontend/app/version.js
+++ b/frontend/app/version.js
@@ -4,6 +4,15 @@ export const APP_VERSION = packageInfo.version;
 
 export const CHANGELOG_ENTRIES = [
   {
+    version: '1.0.2',
+    date: '2026-06-30',
+    items: [
+      'Updated Docker networking so scans can see LAN devices instead of only the Docker host.',
+      'Added configurable frontend backend upstream for host-network deployments.',
+      'Tuned Granian backend concurrency for home use.',
+    ],
+  },
+  {
     version: '1.0.1',
     date: '2026-06-29',
     items: [

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "languard-frontend",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "languard-frontend",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "engines": {
         "node": ">=24"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "languard-frontend",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- Bump LanGuard to 1.0.2.
- Use host networking for backend and scanner containers so ARP discovery can see LAN devices.
- Make the frontend proxy backend upstream configurable for Portainer deployments.
- Tune Granian backend concurrency for home-use deployments.

## Validation
- `sh -n entrypoint.sh`
- `docker compose config --quiet`
- `npm run lint`
- `npm run build`
- `git diff --check`