### PR TITLE
Release 1.0.3 mobile device layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.0.3 - 2026-07-01
+
+- Added a new-version indicator that checks for published releases every 6 hours.
+- Improved the mobile device list so phone screens no longer squeeze table columns.
+- Added tablet, lock, and robot vacuum device icons.
+- Cleaned up frontend Caddyfile formatting for quieter container startup logs.
+
 ## 1.0.0 - 2026-06-29
 
 - Initial LanGuard release.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM python:3.14-slim
 
+ARG APP_VERSION=1.0.3
+
 ENV ENVIRONMENT=production \
+    APP_VERSION=${APP_VERSION} \
     DEBUG=false \
     DB_PATH=/data/db.sqlite3 \
     STATIC_ROOT=/static \

--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@
 </p>
 
 <p align="center">
-  <img alt="Version" src="https://img.shields.io/badge/version-1.0.2-blue">
+  <img alt="Version" src="https://img.shields.io/badge/version-1.0.3-blue">
   <img alt="Release downloads" src="https://img.shields.io/github/downloads/hillaliy/LanGuard/total?label=downloads">
-  <a href="https://github.com/hillaliy/LanGuard/pkgs/container/languard-backend">
+  <a href="https://github.com/users/hillaliy/packages/container/package/languard-backend">
     <img alt="Backend image" src="https://img.shields.io/badge/GHCR-backend-2ea44f">
   </a>
-  <a href="https://github.com/hillaliy/LanGuard/pkgs/container/languard-frontend">
+  <a href="https://github.com/users/hillaliy/packages/container/package/languard-frontend">
     <img alt="Frontend image" src="https://img.shields.io/badge/GHCR-frontend-2ea44f">
   </a>
 </p>

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -67,6 +67,12 @@ def validate_production_settings(environment, secret_key, debug, allowed_hosts):
 BASE_DIR = Path(__file__).resolve().parent.parent
 
 ENVIRONMENT = os.getenv("ENVIRONMENT", "development").strip().lower()
+APP_VERSION = os.getenv("APP_VERSION", "1.0.3")
+LATEST_VERSION_URL = os.getenv(
+    "LATEST_VERSION_URL",
+    "https://raw.githubusercontent.com/hillaliy/LanGuard/main/frontend/package.json",
+)
+VERSION_CHECK_TIMEOUT = float(os.getenv("VERSION_CHECK_TIMEOUT", "3"))
 
 
 # Quick-start development settings - unsuitable for production

--- a/backend/core/tests.py
+++ b/backend/core/tests.py
@@ -84,6 +84,37 @@ class ApiDocsAccessTests(SimpleTestCase):
         self.assertEqual(response.status_code, 200)
 
 
+class VersionStatusTests(SimpleTestCase):
+    def setUp(self):
+        self.client = APIClient()
+
+    @override_settings(
+        APP_VERSION="1.0.2",
+        LATEST_VERSION_URL="https://example.test/package.json",
+        VERSION_CHECK_TIMEOUT=1,
+    )
+    @patch("core.views.urllib.request.urlopen")
+    def test_version_endpoint_returns_latest_public_version(self, urlopen):
+        response_mock = Mock()
+        response_mock.read.return_value = b'{"version": "1.0.3"}'
+        urlopen.return_value.__enter__.return_value = response_mock
+
+        response = self.client.get("/api/v1/version/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["data"]["current_version"], "1.0.2")
+        self.assertEqual(response.data["data"]["latest_version"], "1.0.3")
+        self.assertEqual(response.data["data"]["check_interval_seconds"], 21600)
+
+    @override_settings(APP_VERSION="1.0.2", LATEST_VERSION_URL="")
+    def test_version_endpoint_falls_back_without_latest_source(self):
+        response = self.client.get("/api/v1/version/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["data"]["current_version"], "1.0.2")
+        self.assertIsNone(response.data["data"]["latest_version"])
+
+
 class AuthApiTests(TestCase):
     def setUp(self):
         self.client = APIClient()

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -7,6 +7,7 @@ from .views import (
     UserEditView,
     UserLogoutView,
     setup_status,
+    version_status,
     device,
     events,
     scan_now,
@@ -21,6 +22,7 @@ from .views import (
 urlpatterns = [
     path("register/", UserRegistrationView.as_view(), name="register"),
     path("setup/", setup_status, name="setup-status"),
+    path("version/", version_status, name="version-status"),
     path("login/", UserLoginView.as_view(), name="login"),
     path("edit/", UserEditView.as_view(), name="user-edit"),
     path("logout/", UserLogoutView.as_view(), name="logout"),

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -1,4 +1,7 @@
 import ipaddress
+import json
+import urllib.error
+import urllib.request
 
 from drf_spectacular.utils import OpenApiTypes, extend_schema, inline_serializer
 from rest_framework import status, generics, permissions
@@ -119,6 +122,66 @@ def active_staff_count():
 
 def staff_count():
     return User.objects.filter(is_staff=True).count()
+
+
+def fetch_latest_version():
+    if not settings.LATEST_VERSION_URL:
+        return None
+
+    request = urllib.request.Request(
+        settings.LATEST_VERSION_URL,
+        headers={"User-Agent": "LanGuard"},
+    )
+    try:
+        with urllib.request.urlopen(
+            request,
+            timeout=settings.VERSION_CHECK_TIMEOUT,
+        ) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except (
+        OSError,
+        TimeoutError,
+        urllib.error.URLError,
+        json.JSONDecodeError,
+        UnicodeDecodeError,
+    ) as exc:
+        LOGGER.info("Latest version check failed: %s", exc)
+        return None
+
+    latest_version = payload.get("version")
+    if isinstance(latest_version, str) and latest_version.strip():
+        return latest_version.strip()
+    return None
+
+
+@extend_schema(
+    responses=inline_serializer(
+        name="VersionStatusResponse",
+        fields={
+            "data": inline_serializer(
+                name="VersionStatus",
+                fields={
+                    "current_version": serializers.CharField(),
+                    "latest_version": serializers.CharField(allow_null=True),
+                    "check_interval_seconds": serializers.IntegerField(),
+                },
+            )
+        },
+    ),
+)
+@api_view(["GET"])
+@permission_classes([AllowAny])
+def version_status(request):
+    latest_version = fetch_latest_version()
+    return Response(
+        {
+            "data": {
+                "current_version": settings.APP_VERSION,
+                "latest_version": latest_version,
+                "check_interval_seconds": 21600,
+            }
+        }
+    )
 
 
 @extend_schema(

--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -1,25 +1,25 @@
 :80 {
-    encode zstd gzip
+	encode zstd gzip
 
-    handle /api/v1/* {
-        reverse_proxy {$BACKEND_UPSTREAM:backend:8000}
-    }
+	handle /api/v1/* {
+		reverse_proxy {$BACKEND_UPSTREAM:backend:8000}
+	}
 
-    handle /api/schema/* {
-        reverse_proxy {$BACKEND_UPSTREAM:backend:8000}
-    }
+	handle /api/schema/* {
+		reverse_proxy {$BACKEND_UPSTREAM:backend:8000}
+	}
 
-    handle /admin* {
-        reverse_proxy {$BACKEND_UPSTREAM:backend:8000}
-    }
+	handle /admin* {
+		reverse_proxy {$BACKEND_UPSTREAM:backend:8000}
+	}
 
-    handle /static/* {
-        reverse_proxy {$BACKEND_UPSTREAM:backend:8000}
-    }
+	handle /static/* {
+		reverse_proxy {$BACKEND_UPSTREAM:backend:8000}
+	}
 
-    handle {
-        root * /srv/frontend
-        try_files {path} /index.html
-        file_server
-    }
+	handle {
+		root * /srv/frontend
+		try_files {path} /index.html
+		file_server
+	}
 }

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -266,6 +266,10 @@ textarea {
   width: 100%;
 }
 
+.device-mobile-list {
+  display: none;
+}
+
 .devices-table th,
 .devices-table td {
   vertical-align: middle;
@@ -334,6 +338,47 @@ textarea {
 
 .port-overflow-badge {
   min-width: 40px;
+}
+
+.device-mobile-row {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  border-bottom: 1px solid var(--border-color);
+  color: inherit;
+  cursor: pointer;
+  display: block;
+  letter-spacing: 0;
+  padding: 14px 16px;
+  text-align: left;
+  width: 100%;
+}
+
+.device-mobile-row:hover {
+  background: var(--hover-bg);
+}
+
+.device-mobile-main {
+  min-width: 0;
+}
+
+.device-mobile-icon {
+  align-items: center;
+  color: var(--brand);
+  display: inline-flex;
+  flex: 0 0 auto;
+  justify-content: center;
+  min-height: 28px;
+  width: 24px;
+}
+
+.device-mobile-title {
+  min-width: 0;
+}
+
+.mobile-mono-value {
+  font-variant-numeric: tabular-nums;
+  overflow-wrap: anywhere;
 }
 
 .sortable-header {
@@ -494,5 +539,56 @@ textarea {
 
   .color-scheme-control {
     max-width: 112px;
+  }
+
+  .devices-panel-header {
+    align-items: stretch;
+    gap: 12px;
+  }
+
+  .devices-panel-header,
+  .devices-panel-controls {
+    width: 100%;
+  }
+
+  .devices-panel-controls {
+    display: grid;
+    grid-template-columns: 1fr 92px;
+  }
+
+  .devices-panel-controls > *:last-child {
+    grid-column: 1 / -1;
+    width: 100%;
+  }
+
+  .devices-table {
+    display: none;
+  }
+
+  .device-mobile-list {
+    display: flex;
+  }
+
+  .device-mobile-wide {
+    grid-column: 1 / -1;
+  }
+
+  .device-known-badge {
+    min-width: 64px;
+  }
+
+  .ports-list {
+    flex-wrap: wrap;
+  }
+
+  .devices-pagination {
+    align-items: flex-start;
+    gap: 12px;
+  }
+
+  .devices-pagination .mantine-Pagination-root {
+    max-width: 100%;
+    overflow-x: auto;
+    padding-bottom: 2px;
   }
 }

--- a/frontend/app/page.jsx
+++ b/frontend/app/page.jsx
@@ -47,8 +47,10 @@ import {
   IconDeviceLaptop,
   IconDeviceMobile,
   IconDeviceSpeaker,
+  IconDeviceTablet,
   IconDeviceTv,
   IconHistory,
+  IconLock,
   IconLogout,
   IconMoon,
   IconNetwork,
@@ -68,6 +70,7 @@ import {
   IconUserPlus,
   IconUserMinus,
   IconUserEdit,
+  IconVacuumCleaner,
   IconWifi,
   IconWifiOff,
   IconX,
@@ -82,6 +85,7 @@ import {
 import { APP_VERSION, CHANGELOG_ENTRIES } from './version';
 
 const changelogSeenStorageKey = 'languard_changelog_seen_version';
+const versionCheckFallbackInterval = 6 * 60 * 60 * 1000;
 
 const eventTypeOptions = [
   { value: 'new_device', label: 'New devices' },
@@ -137,6 +141,32 @@ function showErrorNotification(title, message) {
   });
 }
 
+function parseVersionParts(version) {
+  return String(version || '')
+    .replace(/^v/i, '')
+    .split('.')
+    .map((part) => Number.parseInt(part, 10) || 0);
+}
+
+function isNewerVersion(candidate, current) {
+  const candidateParts = parseVersionParts(candidate);
+  const currentParts = parseVersionParts(current);
+  const length = Math.max(candidateParts.length, currentParts.length);
+
+  for (let index = 0; index < length; index += 1) {
+    const candidatePart = candidateParts[index] || 0;
+    const currentPart = currentParts[index] || 0;
+    if (candidatePart > currentPart) {
+      return true;
+    }
+    if (candidatePart < currentPart) {
+      return false;
+    }
+  }
+
+  return false;
+}
+
 function useHydrated() {
   const [hydrated, setHydrated] = useState(false);
 
@@ -152,6 +182,7 @@ const deviceIconOptions = [
   { value: 'desktop', label: 'Desktop', icon: IconDeviceDesktop },
   { value: 'router', label: 'Router', icon: IconRouter },
   { value: 'phone', label: 'Phone', icon: IconDeviceMobile },
+  { value: 'tablet', label: 'Tablet', icon: IconDeviceTablet },
   { value: 'laptop', label: 'Laptop', icon: IconDeviceLaptop },
   { value: 'tv', label: 'TV', icon: IconDeviceTv },
   { value: 'streamer', label: 'Streamer', icon: IconCast },
@@ -162,6 +193,8 @@ const deviceIconOptions = [
   { value: 'thermostat', label: 'Thermostat', icon: IconTemperature },
   { value: 'speaker', label: 'Speaker', icon: IconDeviceSpeaker },
   { value: 'printer', label: 'Printer', icon: IconPrinter },
+  { value: 'lock', label: 'Lock', icon: IconLock },
+  { value: 'robot-vacuum', label: 'Robot vacuum', icon: IconVacuumCleaner },
   { value: 'server', label: 'Server', icon: IconServer },
 ];
 
@@ -171,6 +204,8 @@ function normalizeDeviceIcon(value) {
     device: 'desktop',
     computer: 'desktop',
     mobile: 'phone',
+    ipad: 'tablet',
+    pad: 'tablet',
     television: 'tv',
     cast: 'streamer',
     streaming: 'streamer',
@@ -187,6 +222,13 @@ function normalizeDeviceIcon(value) {
     'thermometer-snow': 'thermostat',
     temperature: 'thermostat',
     audio: 'speaker',
+    security: 'lock',
+    smartlock: 'lock',
+    'smart-lock': 'lock',
+    vacuum: 'robot-vacuum',
+    roomba: 'robot-vacuum',
+    robot: 'robot-vacuum',
+    'vacuum-cleaner': 'robot-vacuum',
     nas: 'server',
   };
   const normalized = aliases[value] || value || 'unknown';
@@ -1316,6 +1358,10 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
   const [activeDevice, setActiveDevice] = useState(null);
   const [changelogOpened, setChangelogOpened] = useState(false);
   const [seenChangelogVersion, setSeenChangelogVersion] = useState(APP_VERSION);
+  const [latestVersion, setLatestVersion] = useState(APP_VERSION);
+  const [versionCheckInterval, setVersionCheckInterval] = useState(
+    versionCheckFallbackInterval
+  );
   const [modalOpened, modal] = useDisclosure(false);
   const [logoutModalOpened, logoutModal] = useDisclosure(false);
   const [usersModalOpened, usersModal] = useDisclosure(false);
@@ -1342,6 +1388,11 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
     deviceStatusOptions.find((option) => option.value === deviceStatus) || null;
   const canManageUsers = Boolean(user?.is_staff || user?.is_superuser);
   const hasUnreadChangelog = seenChangelogVersion !== APP_VERSION;
+  const hasVersionUpdate = isNewerVersion(latestVersion, APP_VERSION);
+  const hasVersionIndicator = hasUnreadChangelog || hasVersionUpdate;
+  const versionTooltip = hasVersionUpdate
+    ? `New version v${latestVersion} is available`
+    : 'Version history';
 
   useEffect(() => {
     tableStateRef.current = {
@@ -1448,6 +1499,27 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
   }, []);
 
   useEffect(() => {
+    async function checkVersion() {
+      try {
+        const payload = await apiRequest('version/');
+        const versionData = payload.data || {};
+        if (versionData.latest_version) {
+          setLatestVersion(versionData.latest_version);
+        }
+        if (versionData.check_interval_seconds) {
+          setVersionCheckInterval(versionData.check_interval_seconds * 1000);
+        }
+      } catch (err) {
+        setLatestVersion(APP_VERSION);
+      }
+    }
+
+    checkVersion();
+    const timer = window.setInterval(checkVersion, versionCheckInterval);
+    return () => window.clearInterval(timer);
+  }, [versionCheckInterval]);
+
+  useEffect(() => {
     const timer = window.setInterval(() => setCurrentTime(new Date()), 30000);
     return () => window.clearInterval(timer);
   }, []);
@@ -1510,15 +1582,15 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
               <Box>
                 <Group gap="xs" wrap="nowrap">
                   <Title order={3}>LanGuard</Title>
-                  <Tooltip label="Version history">
+                  <Tooltip label={versionTooltip}>
                     <button
                       type="button"
-                      className={`version-pill ${hasUnreadChangelog ? 'has-update' : ''}`}
+                      className={`version-pill ${hasVersionIndicator ? 'has-update' : ''}`}
                       onClick={() => setChangelogOpened(true)}
                       aria-label={`LanGuard version ${APP_VERSION}`}
                     >
                       v{APP_VERSION}
-                      {hasUnreadChangelog && <span className="version-dot" aria-hidden="true" />}
+                      {hasVersionIndicator && <span className="version-dot" aria-hidden="true" />}
                     </button>
                   </Tooltip>
                 </Group>
@@ -1615,12 +1687,12 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
 
           <Paper className="content-panel" radius="md">
             <Stack gap={0}>
-              <Group justify="space-between" p="md">
+              <Group className="devices-panel-header" justify="space-between" p="md">
                 <Group>
                   <IconNetwork size={22} />
                   <Title order={4}>Devices</Title>
                 </Group>
-                <Group>
+                <Group className="devices-panel-controls">
                   <Select
                     w={140}
                     placeholder="Status"
@@ -1661,77 +1733,130 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
               </Group>
               <Divider />
               <Table className="devices-table" highlightOnHover verticalSpacing="sm">
-                      <Table.Thead>
-                        <Table.Tr>
-                          <Table.Th className="device-status-cell">Status</Table.Th>
-                          <SortableHeader
-                            field="name"
-                            label="Name"
-                            ordering={deviceOrdering}
-                            onChange={setDeviceOrdering}
-                            className="device-name-cell"
-                          />
-                          <SortableHeader
-                            field="ip"
-                            label="IP"
-                            ordering={deviceOrdering}
-                            onChange={setDeviceOrdering}
-                            className="device-ip-cell"
-                          />
-                          <Table.Th className="device-mac-cell">MAC</Table.Th>
-                          <Table.Th className="device-ports-cell">Ports</Table.Th>
-                          <Table.Th className="device-lastseen-cell">Last seen</Table.Th>
-                          <Table.Th className="device-known-cell">Known</Table.Th>
-                        </Table.Tr>
-                      </Table.Thead>
-                      <Table.Tbody>
-                        {filteredDevices.map((device) => (
-                          <Table.Tr
-                            className="device-row"
-                            key={device.id}
-                            onClick={() => {
-                              setActiveDevice(device);
-                              modal.open();
-                            }}
-                            style={{ cursor: 'pointer' }}
-                          >
-                            <Table.Td className="device-status-cell">
-                              <Group gap="xs">
-                                <span className={`status-dot ${device.online ? 'online' : 'offline'}`} />
-                                {device.online ? 'Online' : 'Offline'}
-                              </Group>
-                            </Table.Td>
-                            <Table.Td className="device-name-cell" fw={600}>
-                              <Group gap="xs" wrap="nowrap">
-                                <span className="device-table-icon">
-                                  <DeviceIcon value={device.icon} size={17} />
-                                </span>
-                                <span className="truncate-cell" title={device.name}>
-                                  {device.name}
-                                </span>
-                              </Group>
-                            </Table.Td>
-                            <Table.Td className="device-ip-cell">{device.ip}</Table.Td>
-                            <Table.Td className="device-mac-cell">{device.mac}</Table.Td>
-                            <Table.Td className="device-ports-cell">
-                              <PortSummary ports={device.open_ports || []} />
-                            </Table.Td>
-                            <Table.Td className="device-lastseen-cell">{formatDate(device.lastseen)}</Table.Td>
-                            <Table.Td className="device-known-cell">
-                              <Badge
-                                className="device-known-badge"
-                                color={device.known ? 'teal' : 'yellow'}
-                                variant="light"
-                              >
-                                {device.known ? 'Known' : 'New'}
-                              </Badge>
-                            </Table.Td>
-                          </Table.Tr>
-                        ))}
-                      </Table.Tbody>
+                <Table.Thead>
+                  <Table.Tr>
+                    <Table.Th className="device-status-cell">Status</Table.Th>
+                    <SortableHeader
+                      field="name"
+                      label="Name"
+                      ordering={deviceOrdering}
+                      onChange={setDeviceOrdering}
+                      className="device-name-cell"
+                    />
+                    <SortableHeader
+                      field="ip"
+                      label="IP"
+                      ordering={deviceOrdering}
+                      onChange={setDeviceOrdering}
+                      className="device-ip-cell"
+                    />
+                    <Table.Th className="device-mac-cell">MAC</Table.Th>
+                    <Table.Th className="device-ports-cell">Ports</Table.Th>
+                    <Table.Th className="device-lastseen-cell">Last seen</Table.Th>
+                    <Table.Th className="device-known-cell">Known</Table.Th>
+                  </Table.Tr>
+                </Table.Thead>
+                <Table.Tbody>
+                  {filteredDevices.map((device) => (
+                    <Table.Tr
+                      className="device-row"
+                      key={device.id}
+                      onClick={() => {
+                        setActiveDevice(device);
+                        modal.open();
+                      }}
+                      style={{ cursor: 'pointer' }}
+                    >
+                      <Table.Td className="device-status-cell">
+                        <Group gap="xs">
+                          <span className={`status-dot ${device.online ? 'online' : 'offline'}`} />
+                          {device.online ? 'Online' : 'Offline'}
+                        </Group>
+                      </Table.Td>
+                      <Table.Td className="device-name-cell" fw={600}>
+                        <Group gap="xs" wrap="nowrap">
+                          <span className="device-table-icon">
+                            <DeviceIcon value={device.icon} size={17} />
+                          </span>
+                          <span className="truncate-cell" title={device.name}>
+                            {device.name}
+                          </span>
+                        </Group>
+                      </Table.Td>
+                      <Table.Td className="device-ip-cell">{device.ip}</Table.Td>
+                      <Table.Td className="device-mac-cell">{device.mac}</Table.Td>
+                      <Table.Td className="device-ports-cell">
+                        <PortSummary ports={device.open_ports || []} />
+                      </Table.Td>
+                      <Table.Td className="device-lastseen-cell">{formatDate(device.lastseen)}</Table.Td>
+                      <Table.Td className="device-known-cell">
+                        <Badge
+                          className="device-known-badge"
+                          color={device.known ? 'teal' : 'yellow'}
+                          variant="light"
+                        >
+                          {device.known ? 'Known' : 'New'}
+                        </Badge>
+                      </Table.Td>
+                    </Table.Tr>
+                  ))}
+                </Table.Tbody>
               </Table>
+              <Stack className="device-mobile-list" gap={0}>
+                {filteredDevices.map((device) => (
+                  <button
+                    type="button"
+                    className="device-mobile-row"
+                    key={device.id}
+                    onClick={() => {
+                      setActiveDevice(device);
+                      modal.open();
+                    }}
+                  >
+                    <Group justify="space-between" align="flex-start" wrap="nowrap">
+                      <Group gap="sm" align="flex-start" wrap="nowrap" className="device-mobile-main">
+                        <span className="device-mobile-icon">
+                          <DeviceIcon value={device.icon} size={19} />
+                        </span>
+                        <Box className="device-mobile-title">
+                          <Text fw={700} className="truncate-cell">{device.name}</Text>
+                          <Group gap="xs" wrap="nowrap">
+                            <span className={`status-dot ${device.online ? 'online' : 'offline'}`} />
+                            <Text size="sm" c="dimmed">{device.online ? 'Online' : 'Offline'}</Text>
+                          </Group>
+                        </Box>
+                      </Group>
+                      <Badge
+                        className="device-known-badge"
+                        color={device.known ? 'teal' : 'yellow'}
+                        variant="light"
+                      >
+                        {device.known ? 'Known' : 'New'}
+                      </Badge>
+                    </Group>
+                    <SimpleGrid cols={2} spacing="xs" mt="sm">
+                      <Box>
+                        <Text size="xs" c="dimmed">IP</Text>
+                        <Text size="sm" className="mobile-mono-value">{device.ip}</Text>
+                      </Box>
+                      <Box>
+                        <Text size="xs" c="dimmed">Last seen</Text>
+                        <Text size="sm">{formatDate(device.lastseen)}</Text>
+                      </Box>
+                      <Box className="device-mobile-wide">
+                        <Text size="xs" c="dimmed">MAC</Text>
+                        <Text size="sm" className="mobile-mono-value">{device.mac}</Text>
+                      </Box>
+                      <Box className="device-mobile-wide">
+                        <Text size="xs" c="dimmed">Ports</Text>
+                        <PortSummary ports={device.open_ports || []} />
+                      </Box>
+                    </SimpleGrid>
+                  </button>
+                ))}
+              </Stack>
               <Divider />
-              <Group justify="space-between" p="md">
+              <Group className="devices-pagination" justify="space-between" p="md">
                 <Text size="sm" c="dimmed">
                   Showing {deviceStart}-{deviceEnd} of {devicePagination.count} devices
                 </Text>
@@ -1935,6 +2060,12 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
       </Modal>
       <Modal opened={changelogOpened} onClose={closeChangelog} title={`What's new in v${APP_VERSION}`} centered>
         <Stack>
+          {hasVersionUpdate && (
+            <Alert color="blue" icon={<IconRefresh size={18} />}>
+              Version v{latestVersion} is available. Pull the latest Docker images and restart
+              the containers to update.
+            </Alert>
+          )}
           {CHANGELOG_ENTRIES.map((entry) => (
             <Box key={entry.version}>
               <Group justify="space-between" mb="xs">

--- a/frontend/app/version.js
+++ b/frontend/app/version.js
@@ -4,6 +4,16 @@ export const APP_VERSION = packageInfo.version;
 
 export const CHANGELOG_ENTRIES = [
   {
+    version: '1.0.3',
+    date: '2026-07-01',
+    items: [
+      'Added a new-version indicator that checks for published releases every 6 hours.',
+      'Improved the mobile device list so phone screens no longer squeeze table columns.',
+      'Added tablet, lock, and robot vacuum device icons.',
+      'Cleaned up frontend Caddyfile formatting for quieter container startup logs.',
+    ],
+  },
+  {
     version: '1.0.2',
     date: '2026-06-30',
     items: [

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "languard-frontend",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "languard-frontend",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "engines": {
         "node": ">=24"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "languard-frontend",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/push_image.sh
+++ b/push_image.sh
@@ -45,7 +45,11 @@ echo "Backend image:  ${BACKEND_IMAGE}:${VERSION}"
 echo "Frontend image: ${FRONTEND_IMAGE}:${VERSION}"
 
 echo "Building backend image..."
-docker build -f "${ROOT_DIR}/Dockerfile" "${BACKEND_TAGS[@]}" "${ROOT_DIR}"
+docker build \
+  --build-arg "APP_VERSION=${VERSION}" \
+  -f "${ROOT_DIR}/Dockerfile" \
+  "${BACKEND_TAGS[@]}" \
+  "${ROOT_DIR}"
 
 echo "Building frontend image..."
 docker build -f "${ROOT_DIR}/frontend/Dockerfile" "${FRONTEND_TAGS[@]}" "${ROOT_DIR}/frontend"


### PR DESCRIPTION
## Summary
- Bump LanGuard to 1.0.3.
- Add backend/frontend version update detection with a 6-hour check interval.
- Improve the mobile device layout so phone screens use compact device rows instead of squeezed desktop columns.
- Add tablet, lock, and robot vacuum device icons.
- Format the frontend Caddyfile and fix README GHCR badge links.

## Validation
- `.venv/bin/python backend/manage.py test core.tests.VersionStatusTests`
- `npm run lint`
- `npm run build`
- `sh -n push_image.sh`
- `docker compose config --quiet`
- `git diff --check`