### PR TITLE
Group Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,11 @@ updates:
       day: monday
       time: "06:00"
       timezone: Asia/Jerusalem
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 1
+    groups:
+      backend-python:
+        patterns:
+          - "*"
     labels:
       - dependencies
       - backend
@@ -19,7 +23,11 @@ updates:
       day: monday
       time: "06:00"
       timezone: Asia/Jerusalem
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 1
+    groups:
+      frontend-npm:
+        patterns:
+          - "*"
     labels:
       - dependencies
       - frontend
@@ -31,7 +39,11 @@ updates:
       day: monday
       time: "06:00"
       timezone: Asia/Jerusalem
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 1
+    groups:
+      backend-docker:
+        patterns:
+          - "*"
     labels:
       - dependencies
       - docker
@@ -43,7 +55,11 @@ updates:
       day: monday
       time: "06:00"
       timezone: Asia/Jerusalem
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 1
+    groups:
+      frontend-docker:
+        patterns:
+          - "*"
     labels:
       - dependencies
       - docker
@@ -55,7 +71,11 @@ updates:
       day: monday
       time: "06:00"
       timezone: Asia/Jerusalem
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 1
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     labels:
       - dependencies
       - github-actions


### PR DESCRIPTION
## Summary
- Group Dependabot updates by ecosystem so one weekly PR is opened per area instead of one PR per dependency.
- Cap each ecosystem at one open Dependabot PR.

## Validation
- `.venv/bin/python -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('.github/dependabot.yml').read_text()); print('ok')"`
- `git diff --check`