### PR TITLE
Ignore ESLint major Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,10 @@ updates:
       frontend-npm:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: eslint
+        update-types:
+          - version-update:semver-major
     labels:
       - dependencies
       - frontend


### PR DESCRIPTION
## Summary
- Ignore ESLint semver-major Dependabot updates for now because ESLint 10 breaks the current Next lint stack.

## Validation
- `.venv/bin/python -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('.github/dependabot.yml').read_text()); print('ok')"`
- `git diff --check`

## Context
PR #31 failed local validation: `npm run lint` crashed with `TypeError: scopeManager.addGlobals is not a function` after the ESLint 10 update.