### PR TITLE
Fix device status layout and Node Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -64,6 +64,10 @@ updates:
       frontend-docker:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: node
+        update-types:
+          - version-update:semver-major
     labels:
       - dependencies
       - docker

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -276,11 +276,12 @@ textarea {
 }
 
 .device-status-cell {
-  width: 9%;
+  width: 11%;
+  white-space: nowrap;
 }
 
 .device-name-cell {
-  width: 22%;
+  width: 20%;
 }
 
 .device-ip-cell {


### PR DESCRIPTION
## Summary
- Keep device status labels such as `Recently seen` on one line in the devices table.
- Ignore semver-major Docker updates for the frontend Node base image so Dependabot does not reopen the Node 24 to 26 PR.

## Validation
- `.venv/bin/python -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('.github/dependabot.yml').read_text()); print('ok')"`
- `npm ci`
- `npm run lint`
- `npm run build`
- `git diff --check`