### PR TITLE
Fix device status filtering and bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.0.7 - 2026-07-05
+
+- Fixed device status filters so Offline, Online, Recently seen, and Sleeping use the same status field shown in the table.
+- Aligned dashboard online/offline counters with the displayed device status.
+- Updated frontend dependencies through Dependabot.
+- Added Dependabot handling for Node Docker image major updates.
+
 ## 1.0.6 - 2026-07-04
 
 - Improved online/offline status with status reasons, per-device grace, ICMP checks, and remembered-port confirmation.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 <p align="center">
-  <img alt="Version" src="https://img.shields.io/badge/version-1.0.6-blue">
+  <img alt="Version" src="https://img.shields.io/badge/version-1.0.7-blue">
   <a href="https://github.com/users/hillaliy/packages/container/package/languard-backend">
     <img alt="Backend image" src="https://img.shields.io/badge/backend-GHCR-2ea44f">
   </a>

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -67,7 +67,7 @@ def validate_production_settings(environment, secret_key, debug, allowed_hosts):
 BASE_DIR = Path(__file__).resolve().parent.parent
 
 ENVIRONMENT = os.getenv("ENVIRONMENT", "development").strip().lower()
-APP_VERSION = os.getenv("APP_VERSION", "1.0.6")
+APP_VERSION = os.getenv("APP_VERSION", "1.0.7")
 LATEST_VERSION_URL = os.getenv(
     "LATEST_VERSION_URL",
     "https://raw.githubusercontent.com/hillaliy/LanGuard/main/frontend/package.json",

--- a/backend/core/tests.py
+++ b/backend/core/tests.py
@@ -1111,11 +1111,28 @@ class ScanApiTests(TestCase):
         self.assertIn("time_zone", response.data)
 
     def test_scan_status_endpoint_returns_latest_scan_and_counters(self):
+        Device.objects.create(
+            name="Stale phone",
+            ip="192.168.1.21",
+            mac="bb:bb:bb:bb:bb:bb",
+            online=False,
+            status=Device.Status.ONLINE,
+        )
+        Device.objects.create(
+            name="Offline camera",
+            ip="192.168.1.22",
+            mac="cc:cc:cc:cc:cc:cc",
+            online=True,
+            status=Device.Status.OFFLINE,
+        )
+
         response = self.client.get("/api/v1/scan/status/")
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["data"]["id"], self.scan_run.id)
-        self.assertEqual(response.data["counters"]["all_devices"], 1)
+        self.assertEqual(response.data["counters"]["all_devices"], 3)
+        self.assertEqual(response.data["counters"]["online_devices"], 2)
+        self.assertEqual(response.data["counters"]["offline_devices"], 1)
         self.assertEqual(response.data["counters"]["unnotified_events"], 1)
 
     def test_scan_status_endpoint_keeps_latest_completed_scan_during_running_scan(self):
@@ -1190,6 +1207,35 @@ class ScanApiTests(TestCase):
             [device["ip"] for device in response.data["data"]],
             ["192.168.1.2", "192.168.1.20", "192.168.1.100"],
         )
+
+    def test_device_endpoint_filters_by_display_status(self):
+        Device.objects.create(
+            name="Status online but stale boolean",
+            ip="192.168.1.21",
+            mac="bb:bb:bb:bb:bb:bb",
+            online=False,
+            status=Device.Status.ONLINE,
+        )
+        offline_device = Device.objects.create(
+            name="Offline camera",
+            ip="192.168.1.22",
+            mac="cc:cc:cc:cc:cc:cc",
+            online=True,
+            status=Device.Status.OFFLINE,
+        )
+
+        response = self.client.get("/api/v1/device/", {"status": Device.Status.OFFLINE})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["pagination"]["count"], 1)
+        self.assertEqual(response.data["data"][0]["id"], offline_device.id)
+        self.assertEqual(response.data["data"][0]["status"], Device.Status.OFFLINE)
+
+    def test_device_endpoint_rejects_invalid_status_filter(self):
+        response = self.client.get("/api/v1/device/", {"status": "gone"})
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("status", response.data)
 
     def test_device_endpoint_counters_include_current_open_ports(self):
         DevicePort.objects.create(device=self.device, port=80, protocol="tcp", open=True)

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -432,8 +432,8 @@ def users(request):
 @permission_classes([permissions.IsAuthenticated])
 def device(request):
     all_devices = Device.objects.all().count()
-    online_devices = Device.objects.filter(online=True).count()
-    offline_devices = Device.objects.filter(online=False).count()
+    online_devices = Device.objects.exclude(status=Device.Status.OFFLINE).count()
+    offline_devices = Device.objects.filter(status=Device.Status.OFFLINE).count()
     new_devices = Device.objects.filter(known=False).count()
     open_ports = DevicePort.objects.filter(open=True).count()
     counters = {
@@ -450,11 +450,16 @@ def device(request):
         if not id_:
             devices = Device.objects.prefetch_related("ports").all()
             online = parse_bool_param(request.query_params, "online")
+            device_status = request.query_params.get("status")
             known = parse_bool_param(request.query_params, "known")
             search = request.query_params.get("search")
             open_port = request.query_params.get("open_port")
 
-            if online is not None:
+            if device_status:
+                if device_status not in Device.Status.values:
+                    raise ValidationError({"status": "Invalid device status."})
+                devices = devices.filter(status=device_status)
+            elif online is not None:
                 devices = devices.filter(online=online)
             if known is not None:
                 devices = devices.filter(known=known)
@@ -639,8 +644,8 @@ def scan_status(request):
             "active_scan": ScanRunSerializer(active_scan).data if active_scan else None,
             "counters": {
                 "all_devices": Device.objects.count(),
-                "online_devices": Device.objects.filter(online=True).count(),
-                "offline_devices": Device.objects.filter(online=False).count(),
+                "online_devices": Device.objects.exclude(status=Device.Status.OFFLINE).count(),
+                "offline_devices": Device.objects.filter(status=Device.Status.OFFLINE).count(),
                 "open_ports": DevicePort.objects.filter(open=True).count(),
                 "unnotified_events": NetworkEvent.objects.filter(notified=False).count(),
             },

--- a/frontend/app/page.jsx
+++ b/frontend/app/page.jsx
@@ -1696,12 +1696,10 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
       const currentTableState = tableStateRef.current;
       const deviceParams = {
         search: currentTableState.search,
-        online:
-          currentTableState.deviceStatus === 'online'
-            ? 'true'
-            : currentTableState.deviceStatus === 'offline'
-              ? 'false'
-              : undefined,
+        status:
+          currentTableState.deviceStatus && currentTableState.deviceStatus !== 'new'
+            ? currentTableState.deviceStatus
+            : undefined,
         known: currentTableState.deviceStatus === 'new' ? 'false' : undefined,
         limit: currentTableState.deviceLimit,
         offset: currentTableState.deviceOffset,

--- a/frontend/app/version.js
+++ b/frontend/app/version.js
@@ -4,6 +4,16 @@ export const APP_VERSION = packageInfo.version;
 
 export const CHANGELOG_ENTRIES = [
   {
+    version: '1.0.7',
+    date: '2026-07-05',
+    items: [
+      'Fixed device status filters so Offline, Online, Recently seen, and Sleeping use the same status field shown in the table.',
+      'Aligned dashboard online/offline counters with the displayed device status.',
+      'Updated frontend dependencies through Dependabot.',
+      'Added Dependabot handling for Node Docker image major updates.',
+    ],
+  },
+  {
     version: '1.0.6',
     date: '2026-07-04',
     items: [

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "languard-frontend",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "languard-frontend",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "dependencies": {
         "@mantine/core": "^9.4.0",
         "@mantine/hooks": "^9.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "languard-frontend",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- Filter devices by displayed status instead of the legacy online boolean
- Align dashboard online/offline counters with device status
- Bump LanGuard to 1.0.7 and update the changelog, including recent dependency updates

## Checks
- .venv/bin/python backend/manage.py test core
- npm run lint
- npm run build