### PR TITLE
Add configurable version check interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed device status filters so Offline, Online, Recently seen, and Sleeping use the same status field shown in the table.
 - Aligned dashboard online/offline counters with the displayed device status.
+- Added a settings option to configure new-version checks in minutes or hours.
 - Updated frontend dependencies through Dependabot.
 - Added Dependabot handling for Node Docker image major updates.
 

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -73,6 +73,7 @@ LATEST_VERSION_URL = os.getenv(
     "https://raw.githubusercontent.com/hillaliy/LanGuard/main/frontend/package.json",
 )
 VERSION_CHECK_TIMEOUT = float(os.getenv("VERSION_CHECK_TIMEOUT", "3"))
+VERSION_CHECK_INTERVAL = int(os.getenv("VERSION_CHECK_INTERVAL", "21600"))
 
 
 # Quick-start development settings - unsuitable for production

--- a/backend/core/admin.py
+++ b/backend/core/admin.py
@@ -67,6 +67,7 @@ class AppSettingsAdmin(admin.ModelAdmin):
     list_display = (
         "ip_range",
         "scan_interval",
+        "version_check_interval",
         "time_zone",
         "notifications_enabled",
         "updated_at",

--- a/backend/core/migrations/0009_appsettings_version_check_interval.py
+++ b/backend/core/migrations/0009_appsettings_version_check_interval.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0008_device_status_metadata"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="appsettings",
+            name="version_check_interval",
+            field=models.PositiveIntegerField(default=21600),
+        ),
+    ]

--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -178,6 +178,7 @@ class AppSettings(models.Model):
     ip_range = models.CharField(max_length=64, default="192.168.1.0/24")
     scan_interval = models.PositiveIntegerField(default=10)
     time_zone = models.CharField(max_length=64, default="UTC")
+    version_check_interval = models.PositiveIntegerField(default=21600)
     notifications_enabled = models.BooleanField(default=True)
     discord_enabled = models.BooleanField(default=True)
     discord_webhook = models.URLField(blank=True, default="")
@@ -199,6 +200,7 @@ class AppSettings(models.Model):
             "ip_range": settings.IP_RANGE,
             "scan_interval": settings.INTERVAL,
             "time_zone": settings.TIME_ZONE,
+            "version_check_interval": settings.VERSION_CHECK_INTERVAL,
             "notifications_enabled": settings.NOTIFICATIONS_ENABLED,
             "discord_enabled": settings.NOTIFICATIONS_ENABLED,
             "discord_webhook": settings.DISCORD_WEBHOOK or "",

--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -163,6 +163,7 @@ class AppSettingsSerializer(serializers.ModelSerializer):
             "ip_range",
             "scan_interval",
             "time_zone",
+            "version_check_interval",
             "notifications_enabled",
             "discord_enabled",
             "discord_webhook",
@@ -210,4 +211,11 @@ class AppSettingsSerializer(serializers.ModelSerializer):
             ZoneInfo(value)
         except ZoneInfoNotFoundError as exc:
             raise serializers.ValidationError("Enter a valid IANA timezone.") from exc
+        return value
+
+    def validate_version_check_interval(self, value):
+        if value < 60:
+            raise serializers.ValidationError("Version check interval must be at least 1 minute.")
+        if value > 604800:
+            raise serializers.ValidationError("Version check interval must be 7 days or less.")
         return value

--- a/backend/core/tests.py
+++ b/backend/core/tests.py
@@ -84,7 +84,7 @@ class ApiDocsAccessTests(SimpleTestCase):
         self.assertEqual(response.status_code, 200)
 
 
-class VersionStatusTests(SimpleTestCase):
+class VersionStatusTests(TestCase):
     def setUp(self):
         self.client = APIClient()
 
@@ -105,6 +105,15 @@ class VersionStatusTests(SimpleTestCase):
         self.assertEqual(response.data["data"]["current_version"], "1.0.2")
         self.assertEqual(response.data["data"]["latest_version"], "1.0.3")
         self.assertEqual(response.data["data"]["check_interval_seconds"], 21600)
+
+    @override_settings(APP_VERSION="1.0.2", LATEST_VERSION_URL="")
+    def test_version_endpoint_uses_saved_check_interval(self):
+        AppSettings.objects.create(version_check_interval=1800)
+
+        response = self.client.get("/api/v1/version/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["data"]["check_interval_seconds"], 1800)
 
     @override_settings(APP_VERSION="1.0.2", LATEST_VERSION_URL="")
     def test_version_endpoint_falls_back_without_latest_source(self):
@@ -1060,6 +1069,7 @@ class ScanApiTests(TestCase):
                 "ip_range": "192.168.1.0/24",
                 "scan_interval": 15,
                 "time_zone": "Asia/Jerusalem",
+                "version_check_interval": 3600,
                 "discord_enabled": False,
                 "telegram_enabled": True,
                 "discord_webhook": "https://discord.example/webhook",
@@ -1074,6 +1084,7 @@ class ScanApiTests(TestCase):
         self.assertEqual(config.ip_range, "192.168.1.0/24")
         self.assertEqual(config.scan_interval, 15)
         self.assertEqual(config.time_zone, "Asia/Jerusalem")
+        self.assertEqual(config.version_check_interval, 3600)
         self.assertFalse(config.discord_enabled)
         self.assertTrue(config.telegram_enabled)
         self.assertEqual(config.discord_webhook, "https://discord.example/webhook")
@@ -1088,6 +1099,17 @@ class ScanApiTests(TestCase):
         self.assertFalse(response.data["data"]["discord_enabled"])
         self.assertTrue(response.data["data"]["telegram_enabled"])
         self.assertTrue(response.data["data"]["discord_configured"])
+        self.assertEqual(response.data["data"]["version_check_interval"], 3600)
+
+    def test_settings_endpoint_rejects_short_version_check_interval(self):
+        response = self.client.put(
+            "/api/v1/settings/",
+            {"version_check_interval": 30},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("version_check_interval", response.data)
 
     @override_settings(SCAN_MAX_HOSTS=256, SCAN_ALLOW_PUBLIC_RANGES=False)
     def test_settings_endpoint_rejects_unsafe_scan_range(self):

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -173,12 +173,13 @@ def fetch_latest_version():
 @permission_classes([AllowAny])
 def version_status(request):
     latest_version = fetch_latest_version()
+    config = AppSettings.load()
     return Response(
         {
             "data": {
                 "current_version": settings.APP_VERSION,
                 "latest_version": latest_version,
-                "check_interval_seconds": 21600,
+                "check_interval_seconds": config.version_check_interval,
             }
         }
     )

--- a/frontend/app/page.jsx
+++ b/frontend/app/page.jsx
@@ -97,6 +97,29 @@ import { APP_VERSION, CHANGELOG_ENTRIES } from './version';
 
 const changelogSeenStorageKey = 'languard_changelog_seen_version';
 const versionCheckFallbackInterval = 6 * 60 * 60 * 1000;
+const versionCheckUnitOptions = [
+  { value: 'minutes', label: 'Minutes' },
+  { value: 'hours', label: 'Hours' },
+];
+
+function splitVersionCheckInterval(seconds) {
+  const normalizedSeconds = Number(seconds) || versionCheckFallbackInterval / 1000;
+  if (normalizedSeconds >= 3600 && normalizedSeconds % 3600 === 0) {
+    return {
+      value: normalizedSeconds / 3600,
+      unit: 'hours',
+    };
+  }
+  return {
+    value: Math.max(1, Math.round(normalizedSeconds / 60)),
+    unit: 'minutes',
+  };
+}
+
+function buildVersionCheckInterval(value, unit) {
+  const normalizedValue = Math.max(1, Number(value) || 1);
+  return normalizedValue * (unit === 'hours' ? 3600 : 60);
+}
 
 const eventTypeOptions = [
   { value: 'new_device', label: 'New devices' },
@@ -1420,6 +1443,8 @@ function SettingsModal({ opened, onClose, onSaved }) {
   const [ipRange, setIpRange] = useState('');
   const [scanInterval, setScanInterval] = useState(10);
   const [timeZone, setTimeZone] = useState('UTC');
+  const [versionCheckValue, setVersionCheckValue] = useState(6);
+  const [versionCheckUnit, setVersionCheckUnit] = useState('hours');
   const [discordEnabled, setDiscordEnabled] = useState(true);
   const [telegramEnabled, setTelegramEnabled] = useState(true);
   const [discordConfigured, setDiscordConfigured] = useState(false);
@@ -1440,6 +1465,9 @@ function SettingsModal({ opened, onClose, onSaved }) {
       setIpRange(data.ip_range || '');
       setScanInterval(data.scan_interval || 10);
       setTimeZone(data.time_zone || 'UTC');
+      const versionInterval = splitVersionCheckInterval(data.version_check_interval);
+      setVersionCheckValue(versionInterval.value);
+      setVersionCheckUnit(versionInterval.unit);
       setDiscordEnabled(Boolean(data.discord_enabled));
       setTelegramEnabled(Boolean(data.telegram_enabled));
       setDiscordConfigured(Boolean(data.discord_configured));
@@ -1469,6 +1497,7 @@ function SettingsModal({ opened, onClose, onSaved }) {
         ip_range: ipRange,
         scan_interval: scanInterval,
         time_zone: timeZone,
+        version_check_interval: buildVersionCheckInterval(versionCheckValue, versionCheckUnit),
         discord_enabled: discordEnabled,
         telegram_enabled: telegramEnabled,
       };
@@ -1476,9 +1505,9 @@ function SettingsModal({ opened, onClose, onSaved }) {
       body.telegram_token = telegramToken;
       body.telegram_user_id = telegramUserId;
 
-      await apiRequest('settings/', { method: 'PUT', body });
+      const savedSettings = await apiRequest('settings/', { method: 'PUT', body });
       await loadSettings();
-      await onSaved();
+      await onSaved(savedSettings.data || {});
       showSuccessNotification('Settings saved', 'Scanner and notification settings were updated.');
       onClose();
     } catch (err) {
@@ -1531,6 +1560,24 @@ function SettingsModal({ opened, onClose, onSaved }) {
         <Text size="xs" c="dimmed">
           Restart the scanner container after changing scan interval or timezone.
         </Text>
+
+        <SimpleGrid cols={{ base: 1, sm: 2 }}>
+          <NumberInput
+            label="Version check interval"
+            value={versionCheckValue}
+            onChange={(value) => setVersionCheckValue(Number(value) || 1)}
+            min={1}
+            max={versionCheckUnit === 'hours' ? 168 : 10080}
+            required
+          />
+          <Select
+            label="Interval unit"
+            data={versionCheckUnitOptions}
+            value={versionCheckUnit}
+            onChange={(value) => setVersionCheckUnit(value || 'hours')}
+            required
+          />
+        </SimpleGrid>
 
         <Divider />
 
@@ -2356,7 +2403,12 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
         <SettingsModal
           opened={settingsModalOpened}
           onClose={settingsModal.close}
-          onSaved={() => loadData({ quiet: true })}
+          onSaved={async (settingsData) => {
+            if (settingsData.version_check_interval) {
+              setVersionCheckInterval(settingsData.version_check_interval * 1000);
+            }
+            await loadData({ quiet: true });
+          }}
         />
       )}
       <Modal opened={logoutModalOpened} onClose={logoutModal.close} title="Log off" centered>

--- a/frontend/app/version.js
+++ b/frontend/app/version.js
@@ -9,6 +9,7 @@ export const CHANGELOG_ENTRIES = [
     items: [
       'Fixed device status filters so Offline, Online, Recently seen, and Sleeping use the same status field shown in the table.',
       'Aligned dashboard online/offline counters with the displayed device status.',
+      'Added a settings option to configure new-version checks in minutes or hours.',
       'Updated frontend dependencies through Dependabot.',
       'Added Dependabot handling for Node Docker image major updates.',
     ],


### PR DESCRIPTION
## Summary
- Add a saved app setting for the new-version check interval
- Expose the interval through the settings and version APIs
- Add settings modal controls for minutes or hours
- Add the change to the existing 1.0.7 changelog entry

## Checks
- .venv/bin/python backend/manage.py makemigrations --check --dry-run
- .venv/bin/python backend/manage.py test core
- npm run lint
- npm run build