### PR TITLE
Add notification rules and scan visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.8 - 2026-07-05
+
+- Added notification rules for new devices, online/offline changes, port changes, and quiet hours.
+- Improved scan visibility with active/idle state, current range, duration, timing, and last error details.
+
 ## 1.0.7 - 2026-07-05
 
 - Fixed device status filters so Offline, Online, Recently seen, and Sleeping use the same status field shown in the table.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 <p align="center">
-  <img alt="Version" src="https://img.shields.io/badge/version-1.0.7-blue">
+  <img alt="Version" src="https://img.shields.io/badge/version-1.0.8-blue">
   <a href="https://github.com/users/hillaliy/packages/container/package/languard-backend">
     <img alt="Backend image" src="https://img.shields.io/badge/backend-GHCR-2ea44f">
   </a>

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -67,7 +67,7 @@ def validate_production_settings(environment, secret_key, debug, allowed_hosts):
 BASE_DIR = Path(__file__).resolve().parent.parent
 
 ENVIRONMENT = os.getenv("ENVIRONMENT", "development").strip().lower()
-APP_VERSION = os.getenv("APP_VERSION", "1.0.7")
+APP_VERSION = os.getenv("APP_VERSION", "1.0.8")
 LATEST_VERSION_URL = os.getenv(
     "LATEST_VERSION_URL",
     "https://raw.githubusercontent.com/hillaliy/LanGuard/main/frontend/package.json",

--- a/backend/core/migrations/0010_appsettings_notification_rules.py
+++ b/backend/core/migrations/0010_appsettings_notification_rules.py
@@ -1,0 +1,45 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0009_appsettings_version_check_interval"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="appsettings",
+            name="notify_new_devices",
+            field=models.BooleanField(default=True),
+        ),
+        migrations.AddField(
+            model_name="appsettings",
+            name="notify_device_online",
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name="appsettings",
+            name="notify_device_offline",
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name="appsettings",
+            name="notify_port_changes",
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name="appsettings",
+            name="notification_quiet_hours_enabled",
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name="appsettings",
+            name="notification_quiet_hours_start",
+            field=models.CharField(default="22:00", max_length=5),
+        ),
+        migrations.AddField(
+            model_name="appsettings",
+            name="notification_quiet_hours_end",
+            field=models.CharField(default="07:00", max_length=5),
+        ),
+    ]

--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -185,6 +185,13 @@ class AppSettings(models.Model):
     telegram_enabled = models.BooleanField(default=True)
     telegram_token = models.CharField(max_length=255, blank=True, default="")
     telegram_user_id = models.CharField(max_length=64, blank=True, default="")
+    notify_new_devices = models.BooleanField(default=True)
+    notify_device_online = models.BooleanField(default=False)
+    notify_device_offline = models.BooleanField(default=False)
+    notify_port_changes = models.BooleanField(default=False)
+    notification_quiet_hours_enabled = models.BooleanField(default=False)
+    notification_quiet_hours_start = models.CharField(max_length=5, default="22:00")
+    notification_quiet_hours_end = models.CharField(max_length=5, default="07:00")
     updated_at = models.DateTimeField(auto_now=True)
 
     class Meta:
@@ -207,6 +214,16 @@ class AppSettings(models.Model):
             "telegram_enabled": settings.NOTIFICATIONS_ENABLED,
             "telegram_token": settings.TELEGRAM_TOKEN or "",
             "telegram_user_id": settings.TELEGRAM_USERID or "",
+            "notify_new_devices": "new_device" in settings.NOTIFICATION_EVENT_TYPES,
+            "notify_device_online": "device_online" in settings.NOTIFICATION_EVENT_TYPES,
+            "notify_device_offline": "device_offline" in settings.NOTIFICATION_EVENT_TYPES,
+            "notify_port_changes": any(
+                event_type in settings.NOTIFICATION_EVENT_TYPES
+                for event_type in ("port_opened", "port_closed")
+            ),
+            "notification_quiet_hours_enabled": False,
+            "notification_quiet_hours_start": "22:00",
+            "notification_quiet_hours_end": "07:00",
         }
         config, _ = cls.objects.get_or_create(singleton_key=1, defaults=defaults)
         return config

--- a/backend/core/notifications.py
+++ b/backend/core/notifications.py
@@ -1,4 +1,6 @@
 import logging
+from datetime import time
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import requests
 from django.conf import settings
@@ -26,7 +28,41 @@ def notification_event_types():
 
 
 def notification_event_allowed(event):
+    app_config = AppSettings.load()
+    if event.event_type == NetworkEvent.EventType.NEW_DEVICE:
+        return app_config.notify_new_devices
+    if event.event_type == NetworkEvent.EventType.DEVICE_ONLINE:
+        return app_config.notify_device_online
+    if event.event_type == NetworkEvent.EventType.DEVICE_OFFLINE:
+        return app_config.notify_device_offline
+    if event.event_type in {
+        NetworkEvent.EventType.PORT_OPENED,
+        NetworkEvent.EventType.PORT_CLOSED,
+    }:
+        return app_config.notify_port_changes
     return event.event_type in notification_event_types()
+
+
+def quiet_hours_active(app_config, now=None):
+    if not app_config.notification_quiet_hours_enabled:
+        return False
+
+    now = now or timezone.now()
+    try:
+        app_timezone = ZoneInfo(app_config.time_zone)
+    except ZoneInfoNotFoundError:
+        app_timezone = timezone.get_current_timezone()
+
+    if timezone.is_naive(now):
+        now = timezone.make_aware(now, app_timezone)
+    local_time = timezone.localtime(now, app_timezone).time()
+    start = time.fromisoformat(app_config.notification_quiet_hours_start)
+    end = time.fromisoformat(app_config.notification_quiet_hours_end)
+    if start == end:
+        return True
+    if start < end:
+        return start <= local_time < end
+    return local_time >= start or local_time < end
 
 
 def mark_notification_skipped(event, reason):
@@ -44,6 +80,10 @@ def notify_event(event):
 
     if not notification_event_allowed(event):
         mark_notification_skipped(event, "event_type_not_enabled")
+        return []
+
+    if quiet_hours_active(app_config):
+        mark_notification_skipped(event, "quiet_hours")
         return []
 
     deliveries = []

--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -172,6 +172,13 @@ class AppSettingsSerializer(serializers.ModelSerializer):
             "telegram_token",
             "telegram_user_id",
             "telegram_configured",
+            "notify_new_devices",
+            "notify_device_online",
+            "notify_device_offline",
+            "notify_port_changes",
+            "notification_quiet_hours_enabled",
+            "notification_quiet_hours_start",
+            "notification_quiet_hours_end",
             "updated_at",
         )
         extra_kwargs = {
@@ -218,4 +225,21 @@ class AppSettingsSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError("Version check interval must be at least 1 minute.")
         if value > 604800:
             raise serializers.ValidationError("Version check interval must be 7 days or less.")
+        return value
+
+    def validate_notification_quiet_hours_start(self, value):
+        return self.validate_quiet_hour(value)
+
+    def validate_notification_quiet_hours_end(self, value):
+        return self.validate_quiet_hour(value)
+
+    def validate_quiet_hour(self, value):
+        import datetime
+
+        if len(value) != 5:
+            raise serializers.ValidationError("Enter time in HH:MM format.")
+        try:
+            datetime.time.fromisoformat(value)
+        except ValueError as exc:
+            raise serializers.ValidationError("Enter time in HH:MM format.") from exc
         return value

--- a/backend/core/tests.py
+++ b/backend/core/tests.py
@@ -716,6 +716,57 @@ class NotificationTests(TestCase):
         TELEGRAM_TOKEN="",
         TELEGRAM_USERID="",
         NOTIFICATION_TIMEOUT=1,
+    )
+    @patch("core.notifications.requests.post")
+    def test_enabled_device_online_rule_sends_delivery(self, post):
+        post.return_value = Mock(raise_for_status=Mock())
+        AppSettings.objects.create(
+            discord_webhook="https://discord.example/webhook",
+            notify_device_online=True,
+        )
+        event = NetworkEvent.objects.create(
+            device=self.device,
+            event_type=NetworkEvent.EventType.DEVICE_ONLINE,
+            message="Camera came online",
+        )
+
+        deliveries = notify_event(event)
+
+        self.assertEqual(len(deliveries), 1)
+        post.assert_called_once()
+        event.refresh_from_db()
+        self.assertTrue(event.notified)
+
+    @override_settings(
+        NOTIFICATIONS_ENABLED=True,
+        DISCORD_WEBHOOK="https://discord.example/webhook",
+        TELEGRAM_TOKEN="",
+        TELEGRAM_USERID="",
+        NOTIFICATION_TIMEOUT=1,
+    )
+    @patch("core.notifications.requests.post")
+    def test_quiet_hours_skip_external_delivery(self, post):
+        AppSettings.objects.create(
+            discord_webhook="https://discord.example/webhook",
+            notification_quiet_hours_enabled=True,
+            notification_quiet_hours_start="00:00",
+            notification_quiet_hours_end="00:00",
+        )
+
+        deliveries = notify_event(self.event)
+
+        self.assertEqual(deliveries, [])
+        post.assert_not_called()
+        self.event.refresh_from_db()
+        self.assertTrue(self.event.notified)
+        self.assertEqual(self.event.metadata["notification_skipped"], "quiet_hours")
+
+    @override_settings(
+        NOTIFICATIONS_ENABLED=True,
+        DISCORD_WEBHOOK="https://discord.example/webhook",
+        TELEGRAM_TOKEN="",
+        TELEGRAM_USERID="",
+        NOTIFICATION_TIMEOUT=1,
         NOTIFICATION_MAX_ATTEMPTS=3,
     )
     @patch("core.notifications.requests.post")
@@ -1072,6 +1123,13 @@ class ScanApiTests(TestCase):
                 "version_check_interval": 3600,
                 "discord_enabled": False,
                 "telegram_enabled": True,
+                "notify_new_devices": True,
+                "notify_device_online": True,
+                "notify_device_offline": True,
+                "notify_port_changes": True,
+                "notification_quiet_hours_enabled": True,
+                "notification_quiet_hours_start": "23:00",
+                "notification_quiet_hours_end": "06:30",
                 "discord_webhook": "https://discord.example/webhook",
                 "telegram_token": "token",
                 "telegram_user_id": "123",
@@ -1087,6 +1145,13 @@ class ScanApiTests(TestCase):
         self.assertEqual(config.version_check_interval, 3600)
         self.assertFalse(config.discord_enabled)
         self.assertTrue(config.telegram_enabled)
+        self.assertTrue(config.notify_new_devices)
+        self.assertTrue(config.notify_device_online)
+        self.assertTrue(config.notify_device_offline)
+        self.assertTrue(config.notify_port_changes)
+        self.assertTrue(config.notification_quiet_hours_enabled)
+        self.assertEqual(config.notification_quiet_hours_start, "23:00")
+        self.assertEqual(config.notification_quiet_hours_end, "06:30")
         self.assertEqual(config.discord_webhook, "https://discord.example/webhook")
         self.assertEqual(config.telegram_token, "token")
         self.assertEqual(config.telegram_user_id, "123")
@@ -1100,6 +1165,12 @@ class ScanApiTests(TestCase):
         self.assertTrue(response.data["data"]["telegram_enabled"])
         self.assertTrue(response.data["data"]["discord_configured"])
         self.assertEqual(response.data["data"]["version_check_interval"], 3600)
+        self.assertTrue(response.data["data"]["notify_device_online"])
+        self.assertTrue(response.data["data"]["notify_device_offline"])
+        self.assertTrue(response.data["data"]["notify_port_changes"])
+        self.assertTrue(response.data["data"]["notification_quiet_hours_enabled"])
+        self.assertEqual(response.data["data"]["notification_quiet_hours_start"], "23:00")
+        self.assertEqual(response.data["data"]["notification_quiet_hours_end"], "06:30")
 
     def test_settings_endpoint_rejects_short_version_check_interval(self):
         response = self.client.put(
@@ -1110,6 +1181,16 @@ class ScanApiTests(TestCase):
 
         self.assertEqual(response.status_code, 400)
         self.assertIn("version_check_interval", response.data)
+
+    def test_settings_endpoint_rejects_bad_quiet_hours(self):
+        response = self.client.put(
+            "/api/v1/settings/",
+            {"notification_quiet_hours_start": "23:00:00"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("notification_quiet_hours_start", response.data)
 
     @override_settings(SCAN_MAX_HOSTS=256, SCAN_ALLOW_PUBLIC_RANGES=False)
     def test_settings_endpoint_rejects_unsafe_scan_range(self):
@@ -1133,6 +1214,9 @@ class ScanApiTests(TestCase):
         self.assertIn("time_zone", response.data)
 
     def test_scan_status_endpoint_returns_latest_scan_and_counters(self):
+        self.scan_run.started_at = timezone.now() - timedelta(minutes=2)
+        self.scan_run.finished_at = timezone.now()
+        self.scan_run.save(update_fields=["started_at", "finished_at"])
         Device.objects.create(
             name="Stale phone",
             ip="192.168.1.21",
@@ -1156,6 +1240,22 @@ class ScanApiTests(TestCase):
         self.assertEqual(response.data["counters"]["online_devices"], 2)
         self.assertEqual(response.data["counters"]["offline_devices"], 1)
         self.assertEqual(response.data["counters"]["unnotified_events"], 1)
+        self.assertFalse(response.data["visibility"]["is_scanning"])
+        self.assertEqual(response.data["visibility"]["current_range"], "192.168.1.0/24")
+        self.assertGreaterEqual(response.data["visibility"]["duration_seconds"], 119)
+
+    def test_scan_status_endpoint_returns_active_scan_visibility(self):
+        running_scan = ScanRun.objects.create(
+            ip_range="192.168.2.0/24",
+            status=ScanRun.Status.RUNNING,
+        )
+
+        response = self.client.get("/api/v1/scan/status/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["active_scan"]["id"], running_scan.id)
+        self.assertTrue(response.data["visibility"]["is_scanning"])
+        self.assertEqual(response.data["visibility"]["current_range"], "192.168.2.0/24")
 
     def test_scan_status_endpoint_keeps_latest_completed_scan_during_running_scan(self):
         running_scan = ScanRun.objects.create(

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -22,6 +22,7 @@ from django.shortcuts import get_object_or_404
 
 import logging
 
+from django.utils import timezone
 from .serializers import (
     AppSettingsSerializer,
     DeviceSerializer,
@@ -639,10 +640,24 @@ def scan_runs(request):
 def scan_status(request):
     latest_scan = ScanRun.objects.exclude(status=ScanRun.Status.RUNNING).first()
     active_scan = ScanRun.objects.filter(status=ScanRun.Status.RUNNING).first()
+    visible_scan = active_scan or latest_scan
+    now = timezone.now()
+    duration_seconds = None
+    if visible_scan:
+        finished_at = visible_scan.finished_at or now
+        duration_seconds = max(0, int((finished_at - visible_scan.started_at).total_seconds()))
     return Response(
         {
             "data": ScanRunSerializer(latest_scan).data if latest_scan else None,
             "active_scan": ScanRunSerializer(active_scan).data if active_scan else None,
+            "visibility": {
+                "is_scanning": active_scan is not None,
+                "current_range": visible_scan.ip_range if visible_scan else "",
+                "started_at": visible_scan.started_at if visible_scan else None,
+                "finished_at": visible_scan.finished_at if visible_scan else None,
+                "duration_seconds": duration_seconds,
+                "last_error": visible_scan.error if visible_scan and visible_scan.error else "",
+            },
             "counters": {
                 "all_devices": Device.objects.count(),
                 "online_devices": Device.objects.exclude(status=Device.Status.OFFLINE).count(),

--- a/frontend/app/page.jsx
+++ b/frontend/app/page.jsx
@@ -592,6 +592,24 @@ function formatDate(value) {
   }).format(new Date(value));
 }
 
+function formatDuration(seconds) {
+  const value = Number(seconds);
+  if (!Number.isFinite(value) || value < 0) {
+    return '-';
+  }
+  const minutes = Math.floor(value / 60);
+  const remainingSeconds = Math.floor(value % 60);
+  if (minutes >= 60) {
+    const hours = Math.floor(minutes / 60);
+    const remainingMinutes = minutes % 60;
+    return `${hours}h ${remainingMinutes}m`;
+  }
+  if (minutes > 0) {
+    return `${minutes}m ${remainingSeconds}s`;
+  }
+  return `${remainingSeconds}s`;
+}
+
 function deviceStatus(device) {
   const statusValue = device?.status || (device?.online ? 'online' : 'offline');
   const labels = {
@@ -1452,6 +1470,13 @@ function SettingsModal({ opened, onClose, onSaved }) {
   const [discordWebhook, setDiscordWebhook] = useState('');
   const [telegramToken, setTelegramToken] = useState('');
   const [telegramUserId, setTelegramUserId] = useState('');
+  const [notifyNewDevices, setNotifyNewDevices] = useState(true);
+  const [notifyDeviceOnline, setNotifyDeviceOnline] = useState(false);
+  const [notifyDeviceOffline, setNotifyDeviceOffline] = useState(false);
+  const [notifyPortChanges, setNotifyPortChanges] = useState(false);
+  const [quietHoursEnabled, setQuietHoursEnabled] = useState(false);
+  const [quietHoursStart, setQuietHoursStart] = useState('22:00');
+  const [quietHoursEnd, setQuietHoursEnd] = useState('07:00');
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
@@ -1475,6 +1500,13 @@ function SettingsModal({ opened, onClose, onSaved }) {
       setDiscordWebhook(data.discord_webhook || '');
       setTelegramToken(data.telegram_token || '');
       setTelegramUserId(data.telegram_user_id || '');
+      setNotifyNewDevices(Boolean(data.notify_new_devices));
+      setNotifyDeviceOnline(Boolean(data.notify_device_online));
+      setNotifyDeviceOffline(Boolean(data.notify_device_offline));
+      setNotifyPortChanges(Boolean(data.notify_port_changes));
+      setQuietHoursEnabled(Boolean(data.notification_quiet_hours_enabled));
+      setQuietHoursStart(data.notification_quiet_hours_start || '22:00');
+      setQuietHoursEnd(data.notification_quiet_hours_end || '07:00');
     } catch (err) {
       setError(err.message);
       showErrorNotification('Could not load settings', err.message);
@@ -1500,6 +1532,13 @@ function SettingsModal({ opened, onClose, onSaved }) {
         version_check_interval: buildVersionCheckInterval(versionCheckValue, versionCheckUnit),
         discord_enabled: discordEnabled,
         telegram_enabled: telegramEnabled,
+        notify_new_devices: notifyNewDevices,
+        notify_device_online: notifyDeviceOnline,
+        notify_device_offline: notifyDeviceOffline,
+        notify_port_changes: notifyPortChanges,
+        notification_quiet_hours_enabled: quietHoursEnabled,
+        notification_quiet_hours_start: quietHoursStart,
+        notification_quiet_hours_end: quietHoursEnd,
       };
       body.discord_webhook = discordWebhook;
       body.telegram_token = telegramToken;
@@ -1508,7 +1547,7 @@ function SettingsModal({ opened, onClose, onSaved }) {
       const savedSettings = await apiRequest('settings/', { method: 'PUT', body });
       await loadSettings();
       await onSaved(savedSettings.data || {});
-      showSuccessNotification('Settings saved', 'Scanner and notification settings were updated.');
+      showSuccessNotification('Settings saved', 'Scanner, version, and notification settings were updated.');
       onClose();
     } catch (err) {
       setError(err.message);
@@ -1578,6 +1617,55 @@ function SettingsModal({ opened, onClose, onSaved }) {
             required
           />
         </SimpleGrid>
+
+        <Divider />
+
+        <Stack gap="sm">
+          <Text fw={700}>Notification rules</Text>
+          <SimpleGrid cols={{ base: 1, sm: 2 }}>
+            <Switch
+              label="New devices"
+              checked={notifyNewDevices}
+              onChange={(event) => setNotifyNewDevices(event.currentTarget.checked)}
+            />
+            <Switch
+              label="Device comes online"
+              checked={notifyDeviceOnline}
+              onChange={(event) => setNotifyDeviceOnline(event.currentTarget.checked)}
+            />
+            <Switch
+              label="Device goes offline"
+              checked={notifyDeviceOffline}
+              onChange={(event) => setNotifyDeviceOffline(event.currentTarget.checked)}
+            />
+            <Switch
+              label="Port changes"
+              checked={notifyPortChanges}
+              onChange={(event) => setNotifyPortChanges(event.currentTarget.checked)}
+            />
+          </SimpleGrid>
+          <SimpleGrid cols={{ base: 1, sm: 3 }}>
+            <Switch
+              label="Quiet hours"
+              checked={quietHoursEnabled}
+              onChange={(event) => setQuietHoursEnabled(event.currentTarget.checked)}
+            />
+            <TextInput
+              type="time"
+              label="Quiet from"
+              value={quietHoursStart}
+              onChange={(event) => setQuietHoursStart(event.currentTarget.value)}
+              disabled={!quietHoursEnabled}
+            />
+            <TextInput
+              type="time"
+              label="Quiet until"
+              value={quietHoursEnd}
+              onChange={(event) => setQuietHoursEnd(event.currentTarget.value)}
+              disabled={!quietHoursEnabled}
+            />
+          </SimpleGrid>
+        </Stack>
 
         <Divider />
 
@@ -1668,6 +1756,7 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
   });
   const [counters, setCounters] = useState({});
   const [scanStatus, setScanStatus] = useState(null);
+  const [scanVisibility, setScanVisibility] = useState(null);
   const [scanRuns, setScanRuns] = useState([]);
   const [events, setEvents] = useState([]);
   const [notifications, setNotifications] = useState([]);
@@ -1787,7 +1876,8 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
         }
       );
       setCounters(deviceData.counters || {});
-      setScanStatus((previous) => statusData.data || previous);
+      setScanStatus(statusData.data || statusData.active_scan || null);
+      setScanVisibility(statusData.visibility || null);
       setScanRuns(runData.data || []);
       setEvents(eventData.data || []);
       setNotifications(notificationData.data || []);
@@ -2242,6 +2332,14 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
                 <Text size="sm" c="dimmed">
                   Last scan: {scanStatus ? formatDate(scanStatus.finished_at || scanStatus.started_at) : '-'}
                 </Text>
+                <Group gap="xs">
+                  <Badge color={scanVisibility?.is_scanning ? 'blue' : 'gray'} variant="light">
+                    {scanVisibility?.is_scanning ? 'Scanning' : 'Idle'}
+                  </Badge>
+                  <Text size="sm" c="dimmed">
+                    Range: {scanVisibility?.current_range || appSettings?.ip_range || '-'}
+                  </Text>
+                </Group>
                 <TextInput
                   label="CIDR range"
                   placeholder={
@@ -2269,6 +2367,32 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
                 <NumberReadout label="Opened" value={scanStatus?.ports_opened} />
                 <NumberReadout label="Closed" value={scanStatus?.ports_closed} />
               </SimpleGrid>
+              <Divider my="sm" />
+              <SimpleGrid cols={{ base: 1, sm: 2 }}>
+                <Box>
+                  <Text size="xs" c="dimmed">Started</Text>
+                  <Text fw={600}>{formatDate(scanVisibility?.started_at)}</Text>
+                </Box>
+                <Box>
+                  <Text size="xs" c="dimmed">Finished</Text>
+                  <Text fw={600}>{formatDate(scanVisibility?.finished_at)}</Text>
+                </Box>
+                <Box>
+                  <Text size="xs" c="dimmed">Duration</Text>
+                  <Text fw={600}>{formatDuration(scanVisibility?.duration_seconds)}</Text>
+                </Box>
+                <Box>
+                  <Text size="xs" c="dimmed">Status</Text>
+                  <Badge color={scanVisibility?.is_scanning ? 'blue' : scanStatus?.status === 'failed' ? 'red' : 'teal'} variant="light">
+                    {scanVisibility?.is_scanning ? 'running' : scanStatus?.status || '-'}
+                  </Badge>
+                </Box>
+              </SimpleGrid>
+              {scanVisibility?.last_error && (
+                <Alert mt="sm" color="red" icon={<IconAlertCircle size={18} />}>
+                  {scanVisibility.last_error}
+                </Alert>
+              )}
             </Paper>
           </SimpleGrid>
 

--- a/frontend/app/version.js
+++ b/frontend/app/version.js
@@ -4,6 +4,14 @@ export const APP_VERSION = packageInfo.version;
 
 export const CHANGELOG_ENTRIES = [
   {
+    version: '1.0.8',
+    date: '2026-07-05',
+    items: [
+      'Added notification rules for new devices, online/offline changes, port changes, and quiet hours.',
+      'Improved scan visibility with active/idle state, current range, duration, timing, and last error details.',
+    ],
+  },
+  {
     version: '1.0.7',
     date: '2026-07-05',
     items: [

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "languard-frontend",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "languard-frontend",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "dependencies": {
         "@mantine/core": "^9.4.0",
         "@mantine/hooks": "^9.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "languard-frontend",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- Add notification rules for new devices, online/offline changes, port changes, and quiet hours
- Improve scan status visibility with active state, range, timing, duration, and last error
- Bump LanGuard to 1.0.8 and update the changelog

## Checks
- .venv/bin/python backend/manage.py makemigrations --check --dry-run
- .venv/bin/python backend/manage.py test core
- npm run lint
- npm run build