### PR TITLE
Fix stale scan status and bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.9 - 2026-07-08
+
+- Fixed stale running scan records so newer completed scans show as finished instead of running.
+- Added README guidance about private/random phone MAC addresses.
+
 ## 1.0.8 - 2026-07-05
 
 - Added notification rules for new devices, online/offline changes, port changes, and quiet hours.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 <p align="center">
-  <img alt="Version" src="https://img.shields.io/badge/version-1.0.8-blue">
+  <img alt="Version" src="https://img.shields.io/badge/version-1.0.9-blue">
   <a href="https://github.com/users/hillaliy/packages/container/package/languard-backend">
     <img alt="Backend image" src="https://img.shields.io/badge/backend-GHCR-2ea44f">
   </a>
@@ -104,6 +104,12 @@ After sign in, open Settings to change the scan range, scan interval, timezone, 
 Portainer will create the stack network automatically.
 
 Backend and scanner use host networking so ARP discovery can see LAN devices. Without host networking, Docker bridge networking may only show the Docker host/gateway.
+
+## Phone MAC Randomization
+
+Modern iPhone and Android devices often use a private/random MAC address per Wi-Fi network. If that address changes, LanGuard will see the same phone as a new device.
+
+For stable tracking, disable private/random MAC addressing for your home Wi-Fi network on the phone, or mark the new entry as known when it appears.
 
 ## Update
 

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -67,7 +67,7 @@ def validate_production_settings(environment, secret_key, debug, allowed_hosts):
 BASE_DIR = Path(__file__).resolve().parent.parent
 
 ENVIRONMENT = os.getenv("ENVIRONMENT", "development").strip().lower()
-APP_VERSION = os.getenv("APP_VERSION", "1.0.8")
+APP_VERSION = os.getenv("APP_VERSION", "1.0.9")
 LATEST_VERSION_URL = os.getenv(
     "LATEST_VERSION_URL",
     "https://raw.githubusercontent.com/hillaliy/LanGuard/main/frontend/package.json",

--- a/backend/core/tests.py
+++ b/backend/core/tests.py
@@ -1269,6 +1269,30 @@ class ScanApiTests(TestCase):
         self.assertEqual(response.data["data"]["id"], self.scan_run.id)
         self.assertEqual(response.data["active_scan"]["id"], running_scan.id)
 
+    def test_scan_status_endpoint_finishes_superseded_running_scan(self):
+        running_scan = ScanRun.objects.create(
+            ip_range="192.168.1.0/24",
+            status=ScanRun.Status.RUNNING,
+            started_at=timezone.now() - timedelta(minutes=30),
+        )
+        self.scan_run.started_at = timezone.now() - timedelta(minutes=5)
+        self.scan_run.finished_at = timezone.now() - timedelta(minutes=1)
+        self.scan_run.save(update_fields=["started_at", "finished_at"])
+
+        response = self.client.get("/api/v1/scan/status/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["data"]["id"], self.scan_run.id)
+        self.assertIsNone(response.data["active_scan"])
+        self.assertFalse(response.data["visibility"]["is_scanning"])
+        self.assertEqual(response.data["visibility"]["finished_at"], self.scan_run.finished_at)
+        running_scan.refresh_from_db()
+        self.assertEqual(running_scan.status, ScanRun.Status.FAILED)
+        self.assertEqual(
+            running_scan.error,
+            "Scan was superseded by a newer completed scan.",
+        )
+
     def test_device_endpoint_paginates_devices(self):
         Device.objects.create(
             name="Tablet",

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -125,6 +125,21 @@ def staff_count():
     return User.objects.filter(is_staff=True).count()
 
 
+def reconcile_scan_status(latest_scan, active_scan):
+    if not latest_scan or not active_scan:
+        return active_scan
+
+    latest_finished_at = latest_scan.finished_at or latest_scan.started_at
+    if latest_finished_at <= active_scan.started_at:
+        return active_scan
+
+    active_scan.status = ScanRun.Status.FAILED
+    active_scan.finished_at = latest_finished_at
+    active_scan.error = "Scan was superseded by a newer completed scan."
+    active_scan.save(update_fields=["status", "finished_at", "error"])
+    return None
+
+
 def fetch_latest_version():
     if not settings.LATEST_VERSION_URL:
         return None
@@ -640,6 +655,7 @@ def scan_runs(request):
 def scan_status(request):
     latest_scan = ScanRun.objects.exclude(status=ScanRun.Status.RUNNING).first()
     active_scan = ScanRun.objects.filter(status=ScanRun.Status.RUNNING).first()
+    active_scan = reconcile_scan_status(latest_scan, active_scan)
     visible_scan = active_scan or latest_scan
     now = timezone.now()
     duration_seconds = None

--- a/frontend/app/version.js
+++ b/frontend/app/version.js
@@ -4,6 +4,14 @@ export const APP_VERSION = packageInfo.version;
 
 export const CHANGELOG_ENTRIES = [
   {
+    version: '1.0.9',
+    date: '2026-07-08',
+    items: [
+      'Fixed stale running scan records so newer completed scans show as finished instead of running.',
+      'Added README guidance about private/random phone MAC addresses.',
+    ],
+  },
+  {
     version: '1.0.8',
     date: '2026-07-05',
     items: [

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "languard-frontend",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "languard-frontend",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "dependencies": {
         "@mantine/core": "^9.4.0",
         "@mantine/hooks": "^9.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "languard-frontend",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- Mark superseded running scan records as failed so newer completed scans show as finished
- Add README guidance for private/random phone MAC addresses
- Bump LanGuard to 1.0.9 and update the changelog

## Checks
- .venv/bin/python backend/manage.py test core
- npm run lint
- npm run build