### PR TITLE
Add gateway detection and risk badges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.10 - 2026-07-10
+
+- Added gateway/router detection from the default network route and marks the gateway as a known router.
+- Added device risk badges with backend risk scoring for unknown devices, risky ports, many open ports, missing vendors, and unstable scan status.
+
 ## 1.0.9 - 2026-07-08
 
 - Fixed stale running scan records so newer completed scans show as finished instead of running.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 <p align="center">
-  <img alt="Version" src="https://img.shields.io/badge/version-1.0.9-blue">
+  <img alt="Version" src="https://img.shields.io/badge/version-1.0.10-blue">
   <a href="https://github.com/users/hillaliy/packages/container/package/languard-backend">
     <img alt="Backend image" src="https://img.shields.io/badge/backend-GHCR-2ea44f">
   </a>

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -67,7 +67,7 @@ def validate_production_settings(environment, secret_key, debug, allowed_hosts):
 BASE_DIR = Path(__file__).resolve().parent.parent
 
 ENVIRONMENT = os.getenv("ENVIRONMENT", "development").strip().lower()
-APP_VERSION = os.getenv("APP_VERSION", "1.0.9")
+APP_VERSION = os.getenv("APP_VERSION", "1.0.10")
 LATEST_VERSION_URL = os.getenv(
     "LATEST_VERSION_URL",
     "https://raw.githubusercontent.com/hillaliy/LanGuard/main/frontend/package.json",

--- a/backend/core/admin.py
+++ b/backend/core/admin.py
@@ -17,8 +17,8 @@ class DevicePortInline(admin.TabularInline):
 
 @admin.register(Device)
 class DeviceAdmin(admin.ModelAdmin):
-    list_display = ("name", "ip", "mac", "vendor", "status", "status_source", "online", "known", "lastseen")
-    list_filter = ("status", "status_source", "online", "known", "vendor")
+    list_display = ("name", "ip", "mac", "vendor", "status", "status_source", "online", "known", "is_gateway", "lastseen")
+    list_filter = ("status", "status_source", "online", "known", "is_gateway", "vendor")
     search_fields = ("name", "ip", "mac", "vendor")
     inlines = [DevicePortInline]
 

--- a/backend/core/migrations/0011_device_is_gateway.py
+++ b/backend/core/migrations/0011_device_is_gateway.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0010_appsettings_notification_rules"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="device",
+            name="is_gateway",
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -40,6 +40,7 @@ class Device(models.Model):
     last_port_scan = models.DateTimeField(blank=True, null=True)
     missed_scans = models.PositiveIntegerField(default=0)
     known = models.BooleanField(default=False)
+    is_gateway = models.BooleanField(default=False)
 
     class Meta:
         ordering = ["-online", "name", "ip"]

--- a/backend/core/scan.py
+++ b/backend/core/scan.py
@@ -1,6 +1,7 @@
 import logging
 import ipaddress
 import socket
+import struct
 
 from django.conf import settings
 from django.utils import timezone
@@ -290,6 +291,33 @@ def validate_ip_range(ip_range):
         raise ValueError("Public IP ranges are disabled.")
 
     return network.with_prefixlen
+
+
+def default_gateway_from_proc_route(path="/proc/net/route"):
+    try:
+        with open(path, encoding="utf-8") as route_file:
+            next(route_file, None)
+            for line in route_file:
+                fields = line.strip().split()
+                if len(fields) < 3:
+                    continue
+                destination, gateway = fields[1], fields[2]
+                if destination != "00000000" or gateway == "00000000":
+                    continue
+                return socket.inet_ntoa(struct.pack("<L", int(gateway, 16)))
+    except (FileNotFoundError, OSError, ValueError):
+        return ""
+    return ""
+
+
+def get_default_gateway_ip():
+    return default_gateway_from_proc_route()
+
+
+def clear_stale_gateways(gateway_ip):
+    if not gateway_ip:
+        return 0
+    return Device.objects.filter(is_gateway=True).exclude(ip=gateway_ip).update(is_gateway=False)
 
 
 def normalize_scan_ports(ports=None):
@@ -621,6 +649,7 @@ def discover_devices(ip_range):
 def scan(ip_range, scan_run=None):
     ip_range = validate_ip_range(ip_range)
     scan_run = scan_run or ScanRun.objects.create(ip_range=ip_range)
+    gateway_ip = get_default_gateway_ip()
     ports_opened = 0
     ports_closed = 0
     new_devices = 0
@@ -636,12 +665,14 @@ def scan(ip_range, scan_run=None):
                 oui=oui,
                 scan_run=scan_run,
                 scan_started_at=scan_started_at,
+                gateway_ip=gateway_ip,
             )
             new_devices += stats["new_devices"]
             ports_opened += stats["ports_opened"]
             ports_closed += stats["ports_closed"]
 
         online_macs = [element[1].hwsrc.lower() for element in answered_list]
+        clear_stale_gateways(gateway_ip)
         mark_missing_devices_offline(online_macs, scan_run=scan_run)
     except Exception as exc:
         scan_run.status = ScanRun.Status.FAILED
@@ -673,7 +704,7 @@ def scan(ip_range, scan_run=None):
     return scan_run
 
 
-def sync_discovered_device(element, oui=None, scan_run=None, scan_started_at=None):
+def sync_discovered_device(element, oui=None, scan_run=None, scan_started_at=None, gateway_ip=""):
     scan_started_at = scan_started_at or timezone.now()
     ip = element[1].psrc
     mac = element[1].hwsrc.lower()
@@ -683,6 +714,7 @@ def sync_discovered_device(element, oui=None, scan_run=None, scan_started_at=Non
     ports_opened = 0
     ports_closed = 0
     new_devices = 0
+    is_gateway = bool(gateway_ip and ip == gateway_ip)
 
     try:
         device = Device.objects.get(mac=mac)
@@ -715,6 +747,13 @@ def sync_discovered_device(element, oui=None, scan_run=None, scan_started_at=Non
             if is_default_device_icon(device.icon):
                 device.icon = identity["icon"]
                 update_fields.append("icon")
+        if is_gateway:
+            device.is_gateway = True
+            device.known = True
+            if is_default_device_name(device.name):
+                device.name = "Gateway"
+            device.icon = "router"
+            update_fields.extend(["is_gateway", "known", "name", "icon"])
         device.save(update_fields=update_fields)
 
         if not was_online:
@@ -726,12 +765,19 @@ def sync_discovered_device(element, oui=None, scan_run=None, scan_started_at=Non
             )
     except Device.DoesNotExist:
         identity = guess_device_identity(hostname, vendor_name, mac)
+        if is_gateway:
+            identity = {
+                "name": "Gateway" if is_default_device_name(identity["name"]) else identity["name"],
+                "icon": "router",
+            }
         device = Device.objects.create(
             icon=identity["icon"],
             name=identity["name"],
             ip=ip,
             mac=mac,
             vendor=vendor_name,
+            known=is_gateway,
+            is_gateway=is_gateway,
             lastseen=scan_started_at,
         )
         set_device_status(

--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -101,8 +101,68 @@ class DevicePortSerializer(serializers.ModelSerializer):
         read_only_fields = ("device", "firstseen", "lastseen")
 
 
+RISKY_PORTS = {
+    21: "FTP",
+    22: "SSH",
+    23: "Telnet",
+    445: "SMB",
+    3389: "Remote Desktop",
+    5900: "VNC",
+    8080: "Admin web",
+}
+HIGH_RISK_PORTS = {23, 445, 3389, 5900}
+
+
+def device_risk(device):
+    score = 0
+    reasons = []
+
+    if not device.known:
+        score += 3
+        reasons.append("New unknown device")
+
+    open_ports = list(device.ports.filter(open=True).values_list("port", "protocol"))
+    risky_ports = [
+        f"{protocol}/{port} ({RISKY_PORTS[port]})"
+        for port, protocol in open_ports
+        if port in RISKY_PORTS
+    ]
+    if risky_ports:
+        high_risk_count = sum(1 for port, _protocol in open_ports if port in HIGH_RISK_PORTS)
+        score += 3 if high_risk_count else 2
+        reasons.append(f"Risky open ports: {', '.join(risky_ports)}")
+
+    if len(open_ports) >= 4:
+        score += 2
+        reasons.append("Many open ports")
+
+    if not device.vendor:
+        score += 1
+        reasons.append("No vendor detected")
+
+    if device.status in {Device.Status.RECENTLY_SEEN, Device.Status.SLEEPING} or device.missed_scans:
+        score += 1
+        reasons.append("Recently missed scans")
+
+    if score >= 5:
+        level = "high"
+    elif score >= 2:
+        level = "medium"
+    else:
+        level = "low"
+
+    return {
+        "level": level,
+        "score": score,
+        "reasons": reasons,
+    }
+
+
 class DeviceSerializer(serializers.ModelSerializer):
     open_ports = serializers.SerializerMethodField()
+    risk_level = serializers.SerializerMethodField()
+    risk_score = serializers.SerializerMethodField()
+    risk_reasons = serializers.SerializerMethodField()
     status_display = serializers.CharField(
         source="get_status_display",
         read_only=True,
@@ -119,6 +179,23 @@ class DeviceSerializer(serializers.ModelSerializer):
     @extend_schema_field(DevicePortSerializer(many=True))
     def get_open_ports(self, obj):
         return DevicePortSerializer(obj.ports.filter(open=True), many=True).data
+
+    def get_device_risk(self, obj):
+        if not hasattr(obj, "_risk_data"):
+            obj._risk_data = device_risk(obj)
+        return obj._risk_data
+
+    @extend_schema_field(serializers.CharField)
+    def get_risk_level(self, obj):
+        return self.get_device_risk(obj)["level"]
+
+    @extend_schema_field(serializers.IntegerField)
+    def get_risk_score(self, obj):
+        return self.get_device_risk(obj)["score"]
+
+    @extend_schema_field(serializers.ListField(child=serializers.CharField()))
+    def get_risk_reasons(self, obj):
+        return self.get_device_risk(obj)["reasons"]
 
 
 class ScanRunSerializer(serializers.ModelSerializer):

--- a/backend/core/tests.py
+++ b/backend/core/tests.py
@@ -21,7 +21,9 @@ from .models import (
 )
 from .notifications import notify_event, retry_failed_notifications
 from .scan import (
+    clear_stale_gateways,
     create_event,
+    default_gateway_from_proc_route,
     discover_devices,
     guess_device_identity,
     mark_missing_devices_offline,
@@ -499,6 +501,56 @@ class ScanStabilityTests(TestCase):
 
         self.assertEqual(identity["name"], "TP-Link")
         self.assertEqual(identity["icon"], "router")
+
+    @patch("builtins.open")
+    def test_default_gateway_from_proc_route(self, open_mock):
+        open_mock.return_value.__enter__.return_value = iter(
+            [
+                "Iface Destination Gateway Flags RefCnt Use Metric Mask MTU Window IRTT\n",
+                "eth0 00000000 0100A8C0 0003 0 0 0 00000000 0 0 0\n",
+            ]
+        )
+
+        self.assertEqual(default_gateway_from_proc_route(), "192.168.0.1")
+
+    @override_settings(PORT_SCAN_ENABLED=False)
+    @patch("core.scan.get_hostname")
+    def test_discovered_gateway_is_marked_known_router(self, get_hostname):
+        get_hostname.return_value = "Device"
+
+        sync_discovered_device(
+            self.scan_element("192.168.0.1", "aa:bb:cc:dd:ee:ff"),
+            oui=None,
+            scan_run=ScanRun.objects.create(ip_range="192.168.0.0/24"),
+            gateway_ip="192.168.0.1",
+        )
+
+        device = Device.objects.get(mac="aa:bb:cc:dd:ee:ff")
+        self.assertTrue(device.is_gateway)
+        self.assertTrue(device.known)
+        self.assertEqual(device.name, "Gateway")
+        self.assertEqual(device.icon, "router")
+
+    def test_clear_stale_gateways_keeps_current_gateway_only(self):
+        current = Device.objects.create(
+            name="Current router",
+            ip="192.168.0.1",
+            mac="aa:bb:cc:dd:ee:01",
+            is_gateway=True,
+        )
+        stale = Device.objects.create(
+            name="Old router",
+            ip="192.168.0.254",
+            mac="aa:bb:cc:dd:ee:02",
+            is_gateway=True,
+        )
+
+        clear_stale_gateways("192.168.0.1")
+
+        current.refresh_from_db()
+        stale.refresh_from_db()
+        self.assertTrue(current.is_gateway)
+        self.assertFalse(stale.is_gateway)
 
     def test_guess_device_identity_uses_plain_vendor_without_mac_suffix(self):
         identity = guess_device_identity(
@@ -1396,6 +1448,37 @@ class ScanApiTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["counters"]["open_ports"], 1)
+
+    def test_device_endpoint_includes_low_risk_badge_data(self):
+        self.device.known = True
+        self.device.vendor = "Apple"
+        self.device.save()
+
+        response = self.client.get("/api/v1/device/")
+
+        self.assertEqual(response.status_code, 200)
+        device = response.data["data"][0]
+        self.assertEqual(device["risk_level"], "low")
+        self.assertEqual(device["risk_score"], 0)
+        self.assertEqual(device["risk_reasons"], [])
+
+    def test_device_endpoint_flags_unknown_device_with_risky_ports(self):
+        self.device.known = False
+        self.device.vendor = ""
+        self.device.save()
+        DevicePort.objects.create(device=self.device, port=22, protocol="tcp", open=True)
+        DevicePort.objects.create(device=self.device, port=445, protocol="tcp", open=True)
+
+        response = self.client.get("/api/v1/device/")
+
+        self.assertEqual(response.status_code, 200)
+        device = response.data["data"][0]
+        self.assertEqual(device["risk_level"], "high")
+        self.assertGreaterEqual(device["risk_score"], 5)
+        self.assertIn("New unknown device", device["risk_reasons"])
+        self.assertTrue(
+            any("Risky open ports" in reason for reason in device["risk_reasons"])
+        )
 
     def test_device_endpoint_rejects_too_large_page_size(self):
         response = self.client.get("/api/v1/device/", {"limit": 101})

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -276,16 +276,16 @@ textarea {
 }
 
 .device-status-cell {
-  width: 11%;
+  width: 10%;
   white-space: nowrap;
 }
 
 .device-name-cell {
-  width: 20%;
+  width: 19%;
 }
 
 .device-ip-cell {
-  width: 13%;
+  width: 12%;
   white-space: nowrap;
 }
 
@@ -296,22 +296,32 @@ textarea {
 }
 
 .device-ports-cell {
-  width: 15%;
+  width: 12%;
+}
+
+.device-risk-cell {
+  width: 8%;
+  white-space: nowrap;
 }
 
 .device-lastseen-cell {
-  width: 15%;
+  width: 14%;
   white-space: nowrap;
 }
 
 .device-known-cell {
-  width: 10%;
+  width: 9%;
   white-space: nowrap;
 }
 
 .device-known-badge {
   min-width: 76px;
   justify-content: center;
+}
+
+.device-risk-badge {
+  justify-content: center;
+  min-width: 64px;
 }
 
 .device-table-icon {

--- a/frontend/app/page.jsx
+++ b/frontend/app/page.jsx
@@ -336,6 +336,9 @@ function DeviceIcon({ value, size = 18 }) {
 
 function deviceMapShape(device) {
   const icon = normalizeDeviceIcon(device.icon);
+  if (device.is_gateway) {
+    return 'router';
+  }
   if (!device.known || icon === 'unknown') {
     return 'unknown';
   }
@@ -355,6 +358,9 @@ function deviceMapShape(device) {
 }
 
 function isRouterDevice(device) {
+  if (device.is_gateway) {
+    return true;
+  }
   const normalizedIcon = normalizeDeviceIcon(device.icon);
   const text = `${device.name || ''} ${device.hostname || ''} ${device.vendor || ''}`.toLowerCase();
   if (normalizedIcon === 'smart-hub' || text.includes('aqara') || text.includes('aqura')) {
@@ -390,9 +396,12 @@ function NetworkMapDeviceNode({ device, onSelectDevice }) {
         <span className="network-device-icon">
           <DeviceIcon value={device.icon} size={22} />
         </span>
-        <Badge color={status.color} variant="light">
-          {status.label}
-        </Badge>
+        <Group gap={4} justify="flex-end" wrap="wrap">
+          <RiskBadge device={device} compact />
+          <Badge color={status.color} variant="light">
+            {status.label}
+          </Badge>
+        </Group>
       </Group>
       <Text fw={800} className="network-node-name">{device.name}</Text>
       <Text size="xs" className="mobile-mono-value">{device.ip}</Text>
@@ -424,7 +433,9 @@ function NetworkMapDeviceSection({ title, devices, onSelectDevice, compact = fal
 }
 
 function NetworkMap({ devices = [], onSelectDevice }) {
-  const routerDevices = devices.filter(isRouterDevice);
+  const routerDevices = devices
+    .filter(isRouterDevice)
+    .sort((left, right) => Number(Boolean(right.is_gateway)) - Number(Boolean(left.is_gateway)));
   const hubDevices = devices.filter((device) => !isRouterDevice(device) && isHubDevice(device));
   const cameraDevices = devices.filter((device) => !isRouterDevice(device) && isCameraDevice(device));
   const networkDevices = devices.filter(
@@ -641,6 +652,45 @@ function DeviceStatusInline({ device, muted = false }) {
       <span className={`status-dot ${status.dot}`} />
       <Text size="sm" c={muted ? 'dimmed' : undefined}>{status.label}</Text>
     </Group>
+  );
+}
+
+function deviceRisk(device) {
+  const level = device?.risk_level || 'low';
+  const labels = {
+    high: 'High',
+    medium: 'Medium',
+    low: 'Low',
+  };
+  const colors = {
+    high: 'red',
+    medium: 'orange',
+    low: 'teal',
+  };
+  const reasons = device?.risk_reasons || [];
+  return {
+    level,
+    label: labels[level] || 'Low',
+    color: colors[level] || 'gray',
+    reasons,
+    tooltip: reasons.length ? reasons.join('\n') : 'No obvious risk',
+  };
+}
+
+function RiskBadge({ device, compact = false }) {
+  const risk = deviceRisk(device);
+
+  return (
+    <Tooltip label={risk.tooltip} multiline withArrow>
+      <Badge
+        className="device-risk-badge"
+        color={risk.color}
+        variant={risk.level === 'low' ? 'light' : 'filled'}
+        size={compact ? 'sm' : 'md'}
+      >
+        {compact ? risk.label : `${risk.label} risk`}
+      </Badge>
+    </Tooltip>
   );
 }
 
@@ -1072,6 +1122,7 @@ function DeviceModal({ device, opened, onClose, onSaved }) {
             )}
             <Text size="sm" c="dimmed">Missed scans: {device?.missed_scans ?? 0}</Text>
           </Group>
+          <RiskBadge device={device} />
         </Group>
 
         {currentStatus.reason && (
@@ -2207,6 +2258,7 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
                         />
                         <Table.Th className="device-mac-cell">MAC</Table.Th>
                         <Table.Th className="device-ports-cell">Ports</Table.Th>
+                        <Table.Th className="device-risk-cell">Risk</Table.Th>
                         <Table.Th className="device-lastseen-cell">Last seen</Table.Th>
                         <Table.Th className="device-known-cell">Known</Table.Th>
                       </Table.Tr>
@@ -2239,6 +2291,9 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
                           <Table.Td className="device-mac-cell">{device.mac}</Table.Td>
                           <Table.Td className="device-ports-cell">
                             <PortSummary ports={device.open_ports || []} />
+                          </Table.Td>
+                          <Table.Td className="device-risk-cell">
+                            <RiskBadge device={device} compact />
                           </Table.Td>
                           <Table.Td className="device-lastseen-cell">{formatDate(device.lastseen)}</Table.Td>
                           <Table.Td className="device-known-cell">
@@ -2275,13 +2330,16 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
                               <DeviceStatusInline device={device} muted />
                             </Box>
                           </Group>
-                          <Badge
-                            className="device-known-badge"
-                            color={device.known ? 'teal' : 'yellow'}
-                            variant="light"
-                          >
-                            {device.known ? 'Known' : 'New'}
-                          </Badge>
+                          <Group gap={6} justify="flex-end" wrap="wrap">
+                            <RiskBadge device={device} compact />
+                            <Badge
+                              className="device-known-badge"
+                              color={device.known ? 'teal' : 'yellow'}
+                              variant="light"
+                            >
+                              {device.known ? 'Known' : 'New'}
+                            </Badge>
+                          </Group>
                         </Group>
                         <SimpleGrid cols={2} spacing="xs" mt="sm">
                           <Box>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "languard-frontend",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "languard-frontend",
-      "version": "1.0.9",
+      "version": "1.0.10",
       "dependencies": {
         "@mantine/core": "^9.4.0",
         "@mantine/hooks": "^9.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "languard-frontend",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

- Adds default gateway/router detection and marks the gateway as a known router.
- Adds computed device risk data to the API and shows risk badges in the device table, mobile list, modal, and network map.
- Bumps LanGuard to 1.0.10 and updates the changelog.

## Validation

- `backend/manage.py makemigrations --check --dry-run`
- `backend/manage.py test core`
- `npm run lint`
- `npm run build`
- `git diff --check`