### PR TITLE
Fix timezone timestamp display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.11 - 2026-07-11
+
+- Fixed dashboard timestamps so timezone-less API dates are treated as UTC and displayed in the configured LanGuard timezone.
+- Added automatic scan-status refresh for the Scan control and Latest scan panels without changing device table pagination.
+- Standardized API and Discord notification timestamps to UTC ISO strings with a `Z` suffix.
+
 ## 1.0.10 - 2026-07-10
 
 - Added gateway/router detection from the default network route and marks the gateway as a known router.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 <p align="center">
-  <img alt="Version" src="https://img.shields.io/badge/version-1.0.10-blue">
+  <img alt="Version" src="https://img.shields.io/badge/version-1.0.11-blue">
   <a href="https://github.com/users/hillaliy/packages/container/package/languard-backend">
     <img alt="Backend image" src="https://img.shields.io/badge/backend-GHCR-2ea44f">
   </a>

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -67,7 +67,7 @@ def validate_production_settings(environment, secret_key, debug, allowed_hosts):
 BASE_DIR = Path(__file__).resolve().parent.parent
 
 ENVIRONMENT = os.getenv("ENVIRONMENT", "development").strip().lower()
-APP_VERSION = os.getenv("APP_VERSION", "1.0.10")
+APP_VERSION = os.getenv("APP_VERSION", "1.0.11")
 LATEST_VERSION_URL = os.getenv(
     "LATEST_VERSION_URL",
     "https://raw.githubusercontent.com/hillaliy/LanGuard/main/frontend/package.json",

--- a/backend/core/datetime_utils.py
+++ b/backend/core/datetime_utils.py
@@ -1,0 +1,13 @@
+from datetime import UTC
+
+from django.utils import timezone
+
+
+def utc_isoformat(value):
+    if value is None:
+        return None
+    if timezone.is_naive(value):
+        value = value.replace(tzinfo=UTC)
+    else:
+        value = value.astimezone(UTC)
+    return value.isoformat().replace("+00:00", "Z")

--- a/backend/core/notifications.py
+++ b/backend/core/notifications.py
@@ -6,6 +6,7 @@ import requests
 from django.conf import settings
 from django.utils import timezone
 
+from .datetime_utils import utc_isoformat
 from .models import AppSettings, NetworkEvent, NotificationDelivery
 
 
@@ -213,7 +214,7 @@ def format_discord_payload(event):
         "description": event.message,
         "color": DISCORD_ALERT_COLOR,
         "fields": fields,
-        "timestamp": event.created_at.isoformat(),
+        "timestamp": utc_isoformat(event.created_at),
         "footer": {"text": "LanGuard"},
     }
     if icon_url:

--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -1,6 +1,7 @@
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 from django.contrib.auth.models import User
+from .datetime_utils import utc_isoformat
 from .models import (
     AppSettings,
     Device,
@@ -19,6 +20,11 @@ def capitalize_name(value):
         "-".join(capitalize_part(part) for part in word.split("-"))
         for word in (value or "").strip().split()
     )
+
+
+class UTCDateTimeField(serializers.DateTimeField):
+    def to_representation(self, value):
+        return utc_isoformat(value)
 
 
 class UserSerializer(serializers.ModelSerializer):
@@ -95,6 +101,9 @@ class UserManagementSerializer(serializers.ModelSerializer):
 
 
 class DevicePortSerializer(serializers.ModelSerializer):
+    firstseen = UTCDateTimeField(read_only=True)
+    lastseen = UTCDateTimeField(read_only=True)
+
     class Meta:
         model = DevicePort
         fields = "__all__"
@@ -159,6 +168,10 @@ def device_risk(device):
 
 
 class DeviceSerializer(serializers.ModelSerializer):
+    firstseen = UTCDateTimeField(read_only=True)
+    lastseen = UTCDateTimeField(read_only=True)
+    last_status_check = UTCDateTimeField(read_only=True)
+    last_port_scan = UTCDateTimeField(read_only=True)
     open_ports = serializers.SerializerMethodField()
     risk_level = serializers.SerializerMethodField()
     risk_score = serializers.SerializerMethodField()
@@ -199,12 +212,16 @@ class DeviceSerializer(serializers.ModelSerializer):
 
 
 class ScanRunSerializer(serializers.ModelSerializer):
+    started_at = UTCDateTimeField(read_only=True)
+    finished_at = UTCDateTimeField(read_only=True)
+
     class Meta:
         model = ScanRun
         fields = "__all__"
 
 
 class NetworkEventSerializer(serializers.ModelSerializer):
+    created_at = UTCDateTimeField(read_only=True)
     event_type_display = serializers.CharField(
         source="get_event_type_display",
         read_only=True,
@@ -216,6 +233,8 @@ class NetworkEventSerializer(serializers.ModelSerializer):
 
 
 class NotificationDeliverySerializer(serializers.ModelSerializer):
+    created_at = UTCDateTimeField(read_only=True)
+    sent_at = UTCDateTimeField(read_only=True)
     channel_display = serializers.CharField(
         source="get_channel_display",
         read_only=True,
@@ -231,6 +250,7 @@ class NotificationDeliverySerializer(serializers.ModelSerializer):
 
 
 class AppSettingsSerializer(serializers.ModelSerializer):
+    updated_at = UTCDateTimeField(read_only=True)
     discord_configured = serializers.SerializerMethodField()
     telegram_configured = serializers.SerializerMethodField()
 

--- a/backend/core/tests.py
+++ b/backend/core/tests.py
@@ -11,6 +11,7 @@ import requests
 from rest_framework.test import APIClient
 
 from backend.settings import validate_production_settings
+from .datetime_utils import utc_isoformat
 from .models import (
     AppSettings,
     Device,
@@ -728,6 +729,7 @@ class NotificationTests(TestCase):
         self.assertEqual(embed["color"], 0xE03131)
         self.assertEqual(embed["author"]["icon_url"], "https://example.com/languard.png")
         self.assertEqual(embed["thumbnail"]["url"], "https://example.com/languard.png")
+        self.assertTrue(embed["timestamp"].endswith("Z"))
         self.assertEqual(
             {field["name"]: field["value"] for field in embed["fields"]},
             {
@@ -1292,8 +1294,13 @@ class ScanApiTests(TestCase):
         self.assertEqual(response.data["counters"]["online_devices"], 2)
         self.assertEqual(response.data["counters"]["offline_devices"], 1)
         self.assertEqual(response.data["counters"]["unnotified_events"], 1)
+        self.assertEqual(response.data["time_zone"], "UTC")
         self.assertFalse(response.data["visibility"]["is_scanning"])
         self.assertEqual(response.data["visibility"]["current_range"], "192.168.1.0/24")
+        self.assertTrue(response.data["data"]["started_at"].endswith("Z"))
+        self.assertTrue(response.data["data"]["finished_at"].endswith("Z"))
+        self.assertTrue(response.data["visibility"]["started_at"].endswith("Z"))
+        self.assertTrue(response.data["visibility"]["finished_at"].endswith("Z"))
         self.assertGreaterEqual(response.data["visibility"]["duration_seconds"], 119)
 
     def test_scan_status_endpoint_returns_active_scan_visibility(self):
@@ -1308,6 +1315,8 @@ class ScanApiTests(TestCase):
         self.assertEqual(response.data["active_scan"]["id"], running_scan.id)
         self.assertTrue(response.data["visibility"]["is_scanning"])
         self.assertEqual(response.data["visibility"]["current_range"], "192.168.2.0/24")
+        self.assertTrue(response.data["active_scan"]["started_at"].endswith("Z"))
+        self.assertTrue(response.data["visibility"]["started_at"].endswith("Z"))
 
     def test_scan_status_endpoint_keeps_latest_completed_scan_during_running_scan(self):
         running_scan = ScanRun.objects.create(
@@ -1337,7 +1346,10 @@ class ScanApiTests(TestCase):
         self.assertEqual(response.data["data"]["id"], self.scan_run.id)
         self.assertIsNone(response.data["active_scan"])
         self.assertFalse(response.data["visibility"]["is_scanning"])
-        self.assertEqual(response.data["visibility"]["finished_at"], self.scan_run.finished_at)
+        self.assertEqual(
+            response.data["visibility"]["finished_at"],
+            utc_isoformat(self.scan_run.finished_at),
+        )
         running_scan.refresh_from_db()
         self.assertEqual(running_scan.status, ScanRun.Status.FAILED)
         self.assertEqual(
@@ -1449,6 +1461,23 @@ class ScanApiTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["counters"]["open_ports"], 1)
 
+    def test_device_endpoint_returns_utc_datetime_strings(self):
+        self.device.last_status_check = timezone.now()
+        self.device.last_port_scan = timezone.now()
+        self.device.save(update_fields=["last_status_check", "last_port_scan"])
+        DevicePort.objects.create(device=self.device, port=80, protocol="tcp", open=True)
+
+        response = self.client.get("/api/v1/device/")
+
+        self.assertEqual(response.status_code, 200)
+        device = response.data["data"][0]
+        self.assertTrue(device["firstseen"].endswith("Z"))
+        self.assertTrue(device["lastseen"].endswith("Z"))
+        self.assertTrue(device["last_status_check"].endswith("Z"))
+        self.assertTrue(device["last_port_scan"].endswith("Z"))
+        self.assertTrue(device["open_ports"][0]["firstseen"].endswith("Z"))
+        self.assertTrue(device["open_ports"][0]["lastseen"].endswith("Z"))
+
     def test_device_endpoint_includes_low_risk_badge_data(self):
         self.device.known = True
         self.device.vendor = "Apple"
@@ -1491,6 +1520,7 @@ class ScanApiTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["data"][0]["id"], self.scan_run.id)
+        self.assertTrue(response.data["data"][0]["started_at"].endswith("Z"))
         self.assertEqual(response.data["pagination"]["count"], 1)
 
     def test_scan_runs_endpoint_filters_by_status(self):
@@ -1511,6 +1541,7 @@ class ScanApiTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["data"][0]["id"], self.event.id)
+        self.assertTrue(response.data["data"][0]["created_at"].endswith("Z"))
         self.assertEqual(response.data["pagination"]["count"], 1)
 
     def test_events_endpoint_filters_by_type_and_notified(self):
@@ -1543,6 +1574,7 @@ class ScanApiTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["pagination"]["count"], 1)
         self.assertEqual(response.data["data"][0]["id"], self.delivery.id)
+        self.assertTrue(response.data["data"][0]["created_at"].endswith("Z"))
 
     @override_settings(SCAN_MAX_HOSTS=256, SCAN_ALLOW_PUBLIC_RANGES=False)
     def test_scan_now_rejects_public_ranges(self):

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -23,6 +23,7 @@ from django.shortcuts import get_object_or_404
 import logging
 
 from django.utils import timezone
+from .datetime_utils import utc_isoformat
 from .serializers import (
     AppSettingsSerializer,
     DeviceSerializer,
@@ -657,6 +658,7 @@ def scan_status(request):
     active_scan = ScanRun.objects.filter(status=ScanRun.Status.RUNNING).first()
     active_scan = reconcile_scan_status(latest_scan, active_scan)
     visible_scan = active_scan or latest_scan
+    app_config = AppSettings.load()
     now = timezone.now()
     duration_seconds = None
     if visible_scan:
@@ -669,11 +671,12 @@ def scan_status(request):
             "visibility": {
                 "is_scanning": active_scan is not None,
                 "current_range": visible_scan.ip_range if visible_scan else "",
-                "started_at": visible_scan.started_at if visible_scan else None,
-                "finished_at": visible_scan.finished_at if visible_scan else None,
+                "started_at": utc_isoformat(visible_scan.started_at) if visible_scan else None,
+                "finished_at": utc_isoformat(visible_scan.finished_at) if visible_scan else None,
                 "duration_seconds": duration_seconds,
                 "last_error": visible_scan.error if visible_scan and visible_scan.error else "",
             },
+            "time_zone": app_config.time_zone,
             "counters": {
                 "all_devices": Device.objects.count(),
                 "online_devices": Device.objects.exclude(status=Device.Status.OFFLINE).count(),

--- a/frontend/app/page.jsx
+++ b/frontend/app/page.jsx
@@ -593,14 +593,36 @@ function ColorSchemeControl() {
   );
 }
 
-function formatDate(value) {
+function normalizeApiDate(value) {
+  if (typeof value !== 'string') {
+    return value;
+  }
+  const trimmedValue = value.trim();
+  if (!trimmedValue) {
+    return trimmedValue;
+  }
+  const normalizedValue = trimmedValue.replace(
+    /^(\d{4}-\d{2}-\d{2})\s+(\d{2}:\d{2}:\d{2})/,
+    '$1T$2'
+  );
+  const hasTime = normalizedValue.includes('T');
+  const hasTimezone = /(?:Z|[+-]\d{2}:?\d{2})$/i.test(normalizedValue);
+  return hasTime && !hasTimezone ? `${normalizedValue}Z` : normalizedValue;
+}
+
+function formatDate(value, timeZone) {
   if (!value) {
+    return '-';
+  }
+  const date = new Date(normalizeApiDate(value));
+  if (Number.isNaN(date.getTime())) {
     return '-';
   }
   return new Intl.DateTimeFormat(undefined, {
     dateStyle: 'medium',
     timeStyle: 'short',
-  }).format(new Date(value));
+    ...(timeZone ? { timeZone } : {}),
+  }).format(date);
 }
 
 function formatDuration(seconds) {
@@ -694,19 +716,21 @@ function RiskBadge({ device, compact = false }) {
   );
 }
 
-function formatTopbarDate(value) {
+function formatTopbarDate(value, timeZone) {
   return new Intl.DateTimeFormat(undefined, {
     weekday: 'short',
     day: 'numeric',
     month: 'short',
     year: 'numeric',
+    ...(timeZone ? { timeZone } : {}),
   }).format(value);
 }
 
-function formatTopbarTime(value) {
+function formatTopbarTime(value, timeZone) {
   return new Intl.DateTimeFormat(undefined, {
     hour: '2-digit',
     minute: '2-digit',
+    ...(timeZone ? { timeZone } : {}),
   }).format(value);
 }
 
@@ -999,7 +1023,7 @@ function DeviceIconPicker({ value, onChange }) {
   );
 }
 
-function DeviceModal({ device, opened, onClose, onSaved }) {
+function DeviceModal({ device, opened, onClose, onSaved, timeZone }) {
   const [icon, setIcon] = useState('');
   const [name, setName] = useState('');
   const [known, setKnown] = useState(false);
@@ -1134,15 +1158,15 @@ function DeviceModal({ device, opened, onClose, onSaved }) {
         <SimpleGrid cols={{ base: 1, sm: 2 }}>
           <Box>
             <Text size="xs" c="dimmed">First seen</Text>
-            <Text size="sm">{formatDate(device?.firstseen)}</Text>
+            <Text size="sm">{formatDate(device?.firstseen, timeZone)}</Text>
           </Box>
           <Box>
             <Text size="xs" c="dimmed">Last seen</Text>
-            <Text size="sm">{formatDate(device?.lastseen)}</Text>
+            <Text size="sm">{formatDate(device?.lastseen, timeZone)}</Text>
           </Box>
           <Box>
             <Text size="xs" c="dimmed">Last port scan</Text>
-            <Text size="sm">{formatDate(device?.last_port_scan)}</Text>
+            <Text size="sm">{formatDate(device?.last_port_scan, timeZone)}</Text>
           </Box>
           <Box>
             <Text size="xs" c="dimmed">Open ports</Text>
@@ -1812,6 +1836,7 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
   const [events, setEvents] = useState([]);
   const [notifications, setNotifications] = useState([]);
   const [appSettings, setAppSettings] = useState(null);
+  const [dashboardTimeZone, setDashboardTimeZone] = useState();
   const [search, setSearch] = useState('');
   const [deviceStatus, setDeviceStatus] = useState('');
   const [inventoryView, setInventoryView] = useState('table');
@@ -1859,6 +1884,7 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
   const versionTooltip = hasVersionUpdate
     ? `New version v${latestVersion} is available`
     : 'Version history';
+  const displayTimeZone = appSettings?.time_zone || dashboardTimeZone || undefined;
 
   useEffect(() => {
     tableStateRef.current = {
@@ -1929,6 +1955,9 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
       setCounters(deviceData.counters || {});
       setScanStatus(statusData.data || statusData.active_scan || null);
       setScanVisibility(statusData.visibility || null);
+      if (statusData.time_zone) {
+        setDashboardTimeZone(statusData.time_zone);
+      }
       setScanRuns(runData.data || []);
       setEvents(eventData.data || []);
       setNotifications(notificationData.data || []);
@@ -1955,9 +1984,36 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
     }
   }
 
+  async function loadScanData({ notifyOnError = false, notifyOnSuccess = false } = {}) {
+    try {
+      const [statusData, runData] = await Promise.all([
+        apiRequest('scan/status/'),
+        apiRequest('scan/runs/', { params: { limit: 8 } }),
+      ]);
+      setScanStatus(statusData.data || statusData.active_scan || null);
+      setScanVisibility(statusData.visibility || null);
+      if (statusData.time_zone) {
+        setDashboardTimeZone(statusData.time_zone);
+      }
+      setScanRuns(runData.data || []);
+      if (notifyOnSuccess) {
+        showSuccessNotification('Scan refreshed', 'Latest scan status loaded.');
+      }
+    } catch (err) {
+      if (notifyOnError) {
+        showErrorNotification('Scan refresh failed', err.message);
+      }
+    }
+  }
+
   useEffect(() => {
     loadData();
     const timer = window.setInterval(() => loadData({ quiet: true }), 60000);
+    return () => window.clearInterval(timer);
+  }, []);
+
+  useEffect(() => {
+    const timer = window.setInterval(() => loadScanData(), 10000);
     return () => window.clearInterval(timer);
   }, []);
 
@@ -2089,10 +2145,10 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
                 <IconClock size={18} />
                 <Box>
                   <Text size="xs" c="dimmed" lh={1.1}>
-                    {formatTopbarDate(currentTime)}
+                    {formatTopbarDate(currentTime, displayTimeZone)}
                   </Text>
                   <Text size="sm" fw={700} lh={1.15}>
-                    {formatTopbarTime(currentTime)}
+                    {formatTopbarTime(currentTime, displayTimeZone)}
                   </Text>
                 </Box>
               </Group>
@@ -2295,7 +2351,9 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
                           <Table.Td className="device-risk-cell">
                             <RiskBadge device={device} compact />
                           </Table.Td>
-                          <Table.Td className="device-lastseen-cell">{formatDate(device.lastseen)}</Table.Td>
+                          <Table.Td className="device-lastseen-cell">
+                            {formatDate(device.lastseen, displayTimeZone)}
+                          </Table.Td>
                           <Table.Td className="device-known-cell">
                             <Badge
                               className="device-known-badge"
@@ -2348,7 +2406,7 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
                           </Box>
                           <Box>
                             <Text size="xs" c="dimmed">Last seen</Text>
-                            <Text size="sm">{formatDate(device.lastseen)}</Text>
+                            <Text size="sm">{formatDate(device.lastseen, displayTimeZone)}</Text>
                           </Box>
                           <Box className="device-mobile-wide">
                             <Text size="xs" c="dimmed">MAC</Text>
@@ -2388,7 +2446,7 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
                   <Title order={4}>Scan control</Title>
                 </Group>
                 <Text size="sm" c="dimmed">
-                  Last scan: {scanStatus ? formatDate(scanStatus.finished_at || scanStatus.started_at) : '-'}
+                  Last scan: {scanStatus ? formatDate(scanStatus.finished_at || scanStatus.started_at, displayTimeZone) : '-'}
                 </Text>
                 <Group gap="xs">
                   <Badge color={scanVisibility?.is_scanning ? 'blue' : 'gray'} variant="light">
@@ -2429,11 +2487,11 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
               <SimpleGrid cols={{ base: 1, sm: 2 }}>
                 <Box>
                   <Text size="xs" c="dimmed">Started</Text>
-                  <Text fw={600}>{formatDate(scanVisibility?.started_at)}</Text>
+                  <Text fw={600}>{formatDate(scanVisibility?.started_at, displayTimeZone)}</Text>
                 </Box>
                 <Box>
                   <Text size="xs" c="dimmed">Finished</Text>
-                  <Text fw={600}>{formatDate(scanVisibility?.finished_at)}</Text>
+                  <Text fw={600}>{formatDate(scanVisibility?.finished_at, displayTimeZone)}</Text>
                 </Box>
                 <Box>
                   <Text size="xs" c="dimmed">Duration</Text>
@@ -2493,7 +2551,7 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
                           </Badge>
                         </Table.Td>
                         <Table.Td>{event.message}</Table.Td>
-                        <Table.Td>{formatDate(event.created_at)}</Table.Td>
+                        <Table.Td>{formatDate(event.created_at, displayTimeZone)}</Table.Td>
                         <Table.Td>
                           <Badge color={event.notified ? 'teal' : 'gray'} variant="light">
                             {event.notified ? 'Handled' : 'Pending'}
@@ -2527,7 +2585,7 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
                           </Badge>
                         </Table.Td>
                         <Table.Td>{run.ip_range}</Table.Td>
-                        <Table.Td>{formatDate(run.started_at)}</Table.Td>
+                        <Table.Td>{formatDate(run.started_at, displayTimeZone)}</Table.Td>
                         <Table.Td>{run.devices_seen}</Table.Td>
                         <Table.Td>{run.ports_opened} / {run.ports_closed}</Table.Td>
                       </Table.Tr>
@@ -2558,7 +2616,7 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
                           </Badge>
                         </Table.Td>
                         <Table.Td>{delivery.attempts}</Table.Td>
-                        <Table.Td>{formatDate(delivery.created_at)}</Table.Td>
+                        <Table.Td>{formatDate(delivery.created_at, displayTimeZone)}</Table.Td>
                       </Table.Tr>
                     ))}
                   </Table.Tbody>
@@ -2574,6 +2632,7 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
         opened={modalOpened}
         onClose={modal.close}
         onSaved={() => loadData({ quiet: true })}
+        timeZone={displayTimeZone}
       />
       <UserManagementModal
         opened={usersModalOpened}

--- a/frontend/app/version.js
+++ b/frontend/app/version.js
@@ -4,6 +4,15 @@ export const APP_VERSION = packageInfo.version;
 
 export const CHANGELOG_ENTRIES = [
   {
+    version: '1.0.11',
+    date: '2026-07-11',
+    items: [
+      'Fixed dashboard timestamps so timezone-less API dates are treated as UTC and displayed in the configured LanGuard timezone.',
+      'Added automatic scan-status refresh for the Scan control and Latest scan panels without changing device table pagination.',
+      'Standardized API and Discord notification timestamps to UTC ISO strings with a Z suffix.',
+    ],
+  },
+  {
     version: '1.0.10',
     date: '2026-07-10',
     items: [

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "languard-frontend",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "languard-frontend",
-      "version": "1.0.10",
+      "version": "1.0.11",
       "dependencies": {
         "@mantine/core": "^9.4.0",
         "@mantine/hooks": "^9.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "languard-frontend",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

- Standardizes API datetime output as UTC ISO strings with a `Z` suffix.
- Uses the configured LanGuard timezone across dashboard timestamps, including events and scan history.
- Keeps scan control/latest scan data automatically refreshed without changing device table pagination.
- Bumps LanGuard to 1.0.11 and updates the changelog.

## Validation

- `backend/manage.py test core`
- `backend/manage.py makemigrations --check --dry-run`
- `npm run lint`
- `npm run build`
- `git diff --check`