### PR TITLE
Release 1.0.12 with mobile table fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.12 - 2026-07-14
+
+- Updated backend dependencies through Dependabot, including Django 6.0.7 and drf-spectacular 0.30.0.
+- Updated the frontend ESLint dependency through Dependabot.
+- Improved the device table layout on mobile landscape and narrow tablet widths so columns use the compact mobile layout before they get cut off.
+
 ## 1.0.11 - 2026-07-11
 
 - Fixed dashboard timestamps so timezone-less API dates are treated as UTC and displayed in the configured LanGuard timezone.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 <p align="center">
-  <img alt="Version" src="https://img.shields.io/badge/version-1.0.11-blue">
+  <img alt="Version" src="https://img.shields.io/badge/version-1.0.12-blue">
   <a href="https://github.com/users/hillaliy/packages/container/package/languard-backend">
     <img alt="Backend image" src="https://img.shields.io/badge/backend-GHCR-2ea44f">
   </a>

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -67,7 +67,7 @@ def validate_production_settings(environment, secret_key, debug, allowed_hosts):
 BASE_DIR = Path(__file__).resolve().parent.parent
 
 ENVIRONMENT = os.getenv("ENVIRONMENT", "development").strip().lower()
-APP_VERSION = os.getenv("APP_VERSION", "1.0.11")
+APP_VERSION = os.getenv("APP_VERSION", "1.0.12")
 LATEST_VERSION_URL = os.getenv(
     "LATEST_VERSION_URL",
     "https://raw.githubusercontent.com/hillaliy/LanGuard/main/frontend/package.json",

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -688,7 +688,7 @@ textarea {
   background: #fab005;
 }
 
-@media (max-width: 720px) {
+@media (max-width: 980px) {
   .auth-shell {
     padding: 16px;
     background-size: 320px;

--- a/frontend/app/version.js
+++ b/frontend/app/version.js
@@ -4,6 +4,15 @@ export const APP_VERSION = packageInfo.version;
 
 export const CHANGELOG_ENTRIES = [
   {
+    version: '1.0.12',
+    date: '2026-07-14',
+    items: [
+      'Updated backend dependencies through Dependabot, including Django 6.0.7 and drf-spectacular 0.30.0.',
+      'Updated the frontend ESLint dependency through Dependabot.',
+      'Improved the device table layout on mobile landscape and narrow tablet widths so columns use the compact mobile layout before they get cut off.',
+    ],
+  },
+  {
     version: '1.0.11',
     date: '2026-07-11',
     items: [

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "languard-frontend",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "languard-frontend",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "dependencies": {
         "@mantine/core": "^9.4.0",
         "@mantine/hooks": "^9.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "languard-frontend",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- Bump LanGuard to 1.0.12 across backend, frontend, README badge, and in-app changelog.
- Add changelog notes for the Dependabot dependency updates.
- Switch the compact mobile table layout to apply up to 980px so mobile landscape and narrow tablet widths do not cut off columns.

## Checks
- `npm run lint`
- `npm run build`
- `.venv/bin/python backend/manage.py test core`
- `.venv/bin/python backend/manage.py makemigrations --check --dry-run`