### PR TITLE
Prepare macOS 1.0.21 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.21 - 2026-08-05
+
+- Refined the native macOS About window into a compact, centered layout.
+- Centered update status and clarified the update and release actions.
+- Added About LanGuard access from the app menu and menu bar.
+
 ## 1.0.20 - 2026-08-05
 
 - Added hostname discovery to native macOS network scans and preserved known hostnames when reverse lookup is unavailable.

--- a/macos/LanGuardMac/Packaging/Info.plist
+++ b/macos/LanGuardMac/Packaging/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.20</string>
+	<string>1.0.21</string>
 	<key>CFBundleVersion</key>
-	<string>17</string>
+	<string>18</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/macos/LanGuardMac/README.md
+++ b/macos/LanGuardMac/README.md
@@ -35,7 +35,7 @@ The app bundle is created at `.build/app/LanGuard.app`.
 
 ```bash
 ./Scripts/build_dmg.sh
-open .build/release/LanGuard-1.0.20.dmg
+open .build/release/LanGuard-1.0.21.dmg
 ```
 
 Drag `LanGuard.app` into `Applications` from the DMG window.

--- a/macos/LanGuardMac/Sources/LanGuardMac/AboutView.swift
+++ b/macos/LanGuardMac/Sources/LanGuardMac/AboutView.swift
@@ -9,82 +9,95 @@ struct AboutView: View {
     @State private var updateState: AboutUpdateState = .idle
 
     var body: some View {
-        ScrollView {
-            VStack(spacing: 24) {
-                VStack(spacing: 12) {
-                    ZStack {
-                        RoundedRectangle(cornerRadius: 22)
-                            .fill(.blue.opacity(0.14))
-                            .frame(width: 104, height: 104)
+        VStack(spacing: 4) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 30, style: .continuous)
+                    .fill(.blue.gradient)
+                    .frame(width: 96, height: 96)
+                    .shadow(color: .blue.opacity(0.24), radius: 12, y: 6)
 
-                        Image(systemName: "shield.lefthalf.filled.badge.checkmark")
-                            .font(.system(size: 60, weight: .semibold))
-                            .foregroundStyle(.blue)
-                    }
-
-                    HStack(alignment: .firstTextBaseline, spacing: 10) {
-                        Text("LanGuard")
-                            .font(.system(size: 40, weight: .semibold, design: .rounded))
-
-                        Text("v\(AppVersion.current)")
-                            .font(.system(size: 15, weight: .semibold, design: .rounded))
-                            .foregroundStyle(.secondary)
-                            .padding(.horizontal, 11)
-                            .padding(.vertical, 5)
-                            .background(.quaternary.opacity(0.7), in: Capsule())
-                            .overlay {
-                                Capsule()
-                                    .stroke(.quaternary)
-                            }
-                            .offset(y: -5)
-                    }
-
-                    Text("Native local network watch for macOS")
-                        .font(.title3)
-                        .foregroundStyle(.secondary)
-                }
-                .frame(maxWidth: .infinity)
-                .padding(.top, 14)
-
-                VStack(spacing: 16) {
-                    AboutSummaryCard()
-
-                    AboutUpdateCard(
-                        updateState: updateState,
-                        releasesURL: releasesURL,
-                        onCheck: checkForUpdates
-                    )
-
-                    LazyVGrid(columns: [GridItem(.adaptive(minimum: 220), spacing: 14)], spacing: 14) {
-                        AboutInfoCard(title: "Platform", value: "macOS 26+", systemImage: "macwindow")
-                        AboutInfoCard(title: "Data", value: "Stored locally", systemImage: "lock.shield")
-                        AboutInfoCard(title: "Mode", value: "Home and client scans", systemImage: "network")
-                    }
-
-                    LazyVGrid(columns: [GridItem(.adaptive(minimum: 240), spacing: 14)], spacing: 14) {
-                        AboutLinkButton(
-                            title: "GitHub",
-                            subtitle: "Source code and releases",
-                            icon: .github,
-                            tint: .primary,
-                            url: projectURL
-                        )
-
-                        AboutLinkButton(
-                            title: "PayPal",
-                            subtitle: "Support development",
-                            icon: .paypal,
-                            tint: .blue,
-                            url: donationURL
-                        )
-                    }
-                }
-                .frame(maxWidth: 820)
+                Image(systemName: "shield.lefthalf.filled.badge.checkmark")
+                    .font(.system(size: 56, weight: .semibold))
+                    .foregroundStyle(.white)
             }
-            .padding(.horizontal, 34)
-            .padding(.vertical, 34)
-            .frame(maxWidth: .infinity, alignment: .center)
+
+            Text("LanGuard")
+                .font(.system(size: 26, weight: .semibold, design: .rounded))
+
+            Text("Native local network watch for macOS")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+
+            Text("Version \(AppVersion.current)")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+
+            VStack(spacing: 2) {
+                Text("© 2026 LanGuard")
+                Text("All rights reserved.")
+            }
+            .font(.callout)
+            .foregroundStyle(.secondary)
+
+            Divider()
+                .frame(maxWidth: 240)
+                .padding(.vertical, 1)
+
+            VStack(spacing: 3) {
+                if case .checking = updateState {
+                    ProgressView()
+                        .controlSize(.small)
+                        .frame(height: 20)
+                } else {
+                    Image(systemName: updateState.icon)
+                        .font(.system(size: 19, weight: .semibold))
+                        .foregroundStyle(updateState.tint)
+                        .frame(height: 20)
+                }
+
+                VStack(spacing: 2) {
+                    Text(updateState.title)
+                        .font(.headline)
+                    Text(updateState.message)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+                .multilineTextAlignment(.center)
+            }
+            .frame(width: 280)
+
+            HStack(spacing: 12) {
+                Button {
+                    checkForUpdates()
+                } label: {
+                    Label("Check for Updates", systemImage: "arrow.triangle.2.circlepath")
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .disabled(updateState == .checking)
+
+                Link(destination: updateReleaseURL) {
+                    Label(updateReleaseTitle, systemImage: "arrow.up.right.square")
+                }
+                .font(.callout)
+            }
+
+            HStack(spacing: 16) {
+                Link(destination: projectURL) {
+                    Label("GitHub", systemImage: "chevron.left.forwardslash.chevron.right")
+                }
+
+                Link(destination: donationURL) {
+                    Label("PayPal", systemImage: "creditcard.fill")
+                }
+            }
+            .font(.callout)
+
         }
+        .frame(width: 340)
+        .padding(16)
+        .multilineTextAlignment(.center)
         .onAppear {
             syncUpdateStateFromSettings()
         }
@@ -92,6 +105,22 @@ struct AboutView: View {
             guard updateState != .checking else { return }
             updateState = AboutUpdateState(versionUpdate)
         }
+    }
+
+    private var updateReleaseURL: URL {
+        if case .updateAvailable(_, let url) = updateState {
+            return url
+        }
+
+        return releasesURL
+    }
+
+    private var updateReleaseTitle: String {
+        if case .updateAvailable = updateState {
+            return "Open Release"
+        }
+
+        return "All Releases"
     }
 
     private func checkForUpdates() {
@@ -144,7 +173,7 @@ private enum AboutUpdateState: Equatable {
         case .idle:
             "Check for updates"
         case .checking:
-            "Checking GitHub Releases"
+            "Checking for updates"
         case .upToDate:
             "LanGuard is up to date"
         case .updateAvailable:
@@ -157,13 +186,13 @@ private enum AboutUpdateState: Equatable {
     var message: String {
         switch self {
         case .idle:
-            "Compare this app with the latest release on GitHub."
+            "Check GitHub for the latest release."
         case .checking:
             "Looking for the newest LanGuard release."
         case .upToDate(let version):
             "v\(version) is the latest release."
         case .updateAvailable(let version, _):
-            "v\(version) is available."
+            "v\(version) is available to download."
         case .failed(let message):
             message
         }
@@ -194,226 +223,6 @@ private enum AboutUpdateState: Equatable {
             .orange
         case .failed:
             .red
-        }
-    }
-}
-
-private struct AboutSummaryCard: View {
-    var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            Text("About LanGuard")
-                .font(.title3.weight(.semibold))
-
-            Text("LanGuard discovers devices on your local network, keeps a local inventory, tracks scan changes, and highlights unknown or risky devices without sending your device list to a server.")
-                .font(.body)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-
-            LazyVGrid(columns: [GridItem(.adaptive(minimum: 220), spacing: 12)], spacing: 12) {
-                AboutFeaturePill(systemImage: "desktopcomputer", text: "Device inventory")
-                AboutFeaturePill(systemImage: "clock.arrow.circlepath", text: "Scan history")
-                AboutFeaturePill(systemImage: "exclamationmark.shield", text: "Risk badges")
-                AboutFeaturePill(systemImage: "person.crop.circle", text: "Guest scan")
-            }
-        }
-        .padding(22)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(.background.secondary, in: RoundedRectangle(cornerRadius: 18))
-        .overlay {
-            RoundedRectangle(cornerRadius: 18)
-                .stroke(.quaternary)
-        }
-    }
-}
-
-private struct AboutUpdateCard: View {
-    let updateState: AboutUpdateState
-    let releasesURL: URL
-    let onCheck: () -> Void
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            HStack(alignment: .center, spacing: 12) {
-                Image(systemName: updateState.icon)
-                    .font(.system(size: 18, weight: .semibold))
-                    .foregroundStyle(updateState.tint)
-                    .frame(width: 38, height: 38)
-                    .background(updateState.tint.opacity(0.12), in: RoundedRectangle(cornerRadius: 11))
-
-                VStack(alignment: .leading, spacing: 3) {
-                    Text(updateState.title)
-                        .font(.headline)
-                    Text(updateState.message)
-                        .font(.callout)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-
-                Spacer(minLength: 12)
-
-                if case .checking = updateState {
-                    ProgressView()
-                        .controlSize(.small)
-                }
-            }
-
-            HStack(spacing: 10) {
-                Button {
-                    onCheck()
-                } label: {
-                    Label("Check for Updates", systemImage: "arrow.triangle.2.circlepath")
-                }
-                .disabled(updateState == .checking)
-
-                Link(destination: updateReleaseURL) {
-                    Label(updateReleaseTitle, systemImage: "arrow.up.right.square")
-                }
-            }
-        }
-        .padding(18)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(.background.secondary, in: RoundedRectangle(cornerRadius: 18))
-        .overlay {
-            RoundedRectangle(cornerRadius: 18)
-                .stroke(.quaternary)
-        }
-    }
-
-    private var updateReleaseURL: URL {
-        if case .updateAvailable(_, let url) = updateState {
-            return url
-        }
-
-        return releasesURL
-    }
-
-    private var updateReleaseTitle: String {
-        if case .updateAvailable = updateState {
-            return "Open Release"
-        }
-
-        return "All Releases"
-    }
-}
-
-private struct AboutFeaturePill: View {
-    let systemImage: String
-    let text: String
-
-    var body: some View {
-        Label(text, systemImage: systemImage)
-            .font(.callout.weight(.medium))
-            .foregroundStyle(.secondary)
-            .padding(.horizontal, 12)
-            .padding(.vertical, 10)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(.background, in: RoundedRectangle(cornerRadius: 12))
-            .overlay {
-                RoundedRectangle(cornerRadius: 12)
-                    .stroke(.quaternary)
-            }
-    }
-}
-
-private struct AboutLinkButton: View {
-    let title: String
-    let subtitle: String
-    let icon: AboutBrandIcon.Kind
-    let tint: Color
-    let url: URL
-
-    var body: some View {
-        Link(destination: url) {
-            HStack(spacing: 12) {
-                AboutBrandIcon(kind: icon, tint: tint)
-
-                VStack(alignment: .leading, spacing: 3) {
-                    Text(title)
-                        .font(.headline)
-                        .foregroundStyle(.primary)
-
-                    Text(subtitle)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                }
-
-                Spacer(minLength: 0)
-
-                Image(systemName: "arrow.up.right")
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(.secondary)
-            }
-            .padding(14)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(.background.secondary, in: RoundedRectangle(cornerRadius: 14))
-            .overlay {
-                RoundedRectangle(cornerRadius: 14)
-                    .stroke(.quaternary)
-            }
-        }
-        .buttonStyle(.plain)
-        .help(url.absoluteString)
-    }
-}
-
-private struct AboutBrandIcon: View {
-    enum Kind {
-        case github
-        case paypal
-    }
-
-    let kind: Kind
-    let tint: Color
-
-    var body: some View {
-        ZStack {
-            RoundedRectangle(cornerRadius: 10)
-                .fill(tint.opacity(0.12))
-
-            switch kind {
-            case .github:
-                Image(systemName: "chevron.left.forwardslash.chevron.right")
-                    .font(.system(size: 18, weight: .bold))
-                    .foregroundStyle(tint)
-            case .paypal:
-                Image(systemName: "creditcard.fill")
-                    .font(.system(size: 18, weight: .bold))
-                    .foregroundStyle(tint)
-            }
-        }
-        .frame(width: 40, height: 40)
-    }
-}
-
-private struct AboutInfoCard: View {
-    let title: String
-    let value: String
-    let systemImage: String
-
-    var body: some View {
-        HStack(spacing: 12) {
-            Image(systemName: systemImage)
-                .font(.system(size: 17, weight: .semibold))
-                .foregroundStyle(.blue)
-                .frame(width: 34, height: 34)
-                .background(.blue.opacity(0.12), in: RoundedRectangle(cornerRadius: 9))
-
-            VStack(alignment: .leading, spacing: 2) {
-                Text(title)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                Text(value)
-                    .font(.headline)
-            }
-
-            Spacer(minLength: 0)
-        }
-        .padding(12)
-        .background(.background.secondary, in: RoundedRectangle(cornerRadius: 14))
-        .overlay {
-            RoundedRectangle(cornerRadius: 14)
-                .stroke(.quaternary)
         }
     }
 }

--- a/macos/LanGuardMac/Sources/LanGuardMac/ContentView.swift
+++ b/macos/LanGuardMac/Sources/LanGuardMac/ContentView.swift
@@ -87,8 +87,6 @@ struct ContentView: View {
             ScanHistoryView()
         case .settings:
             SettingsView()
-        case .about:
-            AboutView()
         }
     }
 }
@@ -100,7 +98,6 @@ private enum AppSection: String, CaseIterable, Identifiable {
     case guestScan
     case scanHistory
     case settings
-    case about
 
     var id: String { rawValue }
 
@@ -112,7 +109,6 @@ private enum AppSection: String, CaseIterable, Identifiable {
         case .guestScan: "Guest Scan"
         case .scanHistory: "Scan History"
         case .settings: "Settings"
-        case .about: "About"
         }
     }
 
@@ -124,7 +120,6 @@ private enum AppSection: String, CaseIterable, Identifiable {
         case .guestScan: "person.crop.circle"
         case .scanHistory: "clock.arrow.circlepath"
         case .settings: "gearshape"
-        case .about: "info.circle"
         }
     }
 }

--- a/macos/LanGuardMac/Sources/LanGuardMac/HeaderView.swift
+++ b/macos/LanGuardMac/Sources/LanGuardMac/HeaderView.swift
@@ -51,7 +51,7 @@ enum AppVersion {
     static var current: String {
         let bundleVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
         let normalizedVersion = bundleVersion?.trimmingCharacters(in: .whitespacesAndNewlines)
-        return normalizedVersion?.isEmpty == false ? normalizedVersion! : "1.0.20"
+        return normalizedVersion?.isEmpty == false ? normalizedVersion! : "1.0.21"
     }
 }
 

--- a/macos/LanGuardMac/Sources/LanGuardMac/LanGuardMacApp.swift
+++ b/macos/LanGuardMac/Sources/LanGuardMac/LanGuardMacApp.swift
@@ -12,6 +12,15 @@ struct LanGuardMacApp: App {
         }
         .windowStyle(.hiddenTitleBar)
 
+        Window("About LanGuard", id: "about") {
+            AboutView()
+                .environment(appModel)
+                .frame(minWidth: 320, idealWidth: 340, maxWidth: 380,
+                       minHeight: 340, idealHeight: 360, maxHeight: 390)
+        }
+        .defaultSize(width: 340, height: 360)
+        .windowResizability(.contentSize)
+
         MenuBarExtra {
             LanGuardMenuBarView()
                 .environment(appModel)
@@ -22,6 +31,9 @@ struct LanGuardMacApp: App {
 
         Settings {
             SettingsView()
+        }
+        .commands {
+            AboutCommands()
         }
     }
 }
@@ -35,6 +47,12 @@ private struct LanGuardMenuBarView: View {
             showMainWindow()
         } label: {
             Label("Show LanGuard", systemImage: "macwindow")
+        }
+
+        Button {
+            showAboutWindow()
+        } label: {
+            Label("About LanGuard", systemImage: "info.circle")
         }
 
         Button {
@@ -71,6 +89,11 @@ private struct LanGuardMenuBarView: View {
         NSApp.activate(ignoringOtherApps: true)
     }
 
+    private func showAboutWindow() {
+        openWindow(id: "about")
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
     private var offlineCount: Int {
         appModel.devices.filter { $0.status == .offline }.count
     }
@@ -83,6 +106,19 @@ private struct LanGuardMenuBarView: View {
             "Completed"
         case .failed:
             "Failed"
+        }
+    }
+}
+
+private struct AboutCommands: Commands {
+    @Environment(\.openWindow) private var openWindow
+
+    var body: some Commands {
+        CommandGroup(replacing: .appInfo) {
+            Button("About LanGuard") {
+                openWindow(id: "about")
+                NSApp.activate(ignoringOtherApps: true)
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Refine the native macOS About window and update status layout.
- Add About LanGuard access from the app menu and menu bar.
- Bump macOS bundle metadata and DMG documentation to 1.0.21.

## Verification
- `swift test --package-path macos/LanGuardMac`
- 48 tests passed