### PR TITLE
Release 1.0.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.14-slim
 
-ARG APP_VERSION=1.0.20
+ARG APP_VERSION=1.0.23
 
 ENV ENVIRONMENT=production \
     APP_VERSION=${APP_VERSION} \
@@ -17,6 +17,7 @@ COPY ./requirements.txt .
 RUN pip install -r requirements.txt
 
 COPY ./backend /app
+COPY ./macos/LanGuardMac/Resources/manuf /app/core/resources/manuf
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 <p align="center">
-  <img alt="Version" src="https://img.shields.io/badge/version-1.0.22-blue">
+  <img alt="Version" src="https://img.shields.io/badge/version-1.0.23-blue">
   <a href="https://github.com/users/hillaliy/packages/container/package/languard-backend">
     <img alt="Backend image" src="https://img.shields.io/badge/backend-GHCR-2ea44f">
   </a>

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -67,7 +67,7 @@ def validate_production_settings(environment, secret_key, debug, allowed_hosts):
 BASE_DIR = Path(__file__).resolve().parent.parent
 
 ENVIRONMENT = os.getenv("ENVIRONMENT", "development").strip().lower()
-APP_VERSION = os.getenv("APP_VERSION", "1.0.22")
+APP_VERSION = os.getenv("APP_VERSION", "1.0.23")
 LATEST_VERSION_URL = os.getenv(
     "LATEST_VERSION_URL",
     "https://raw.githubusercontent.com/hillaliy/LanGuard/main/frontend/package.json",

--- a/backend/core/scan.py
+++ b/backend/core/scan.py
@@ -1,5 +1,7 @@
 import logging
 import ipaddress
+import os
+import random
 import socket
 import struct
 
@@ -121,12 +123,282 @@ DEVICE_GUESS_RULES = [
         "ports": (22,),
     },
 ]
+
+MANUF_PATHS = (
+    os.path.join(os.path.dirname(__file__), "resources", "manuf"),
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "..",
+            "macos",
+            "LanGuardMac",
+            "Resources",
+            "manuf",
+        )
+    ),
+)
+
+
+def mac_bytes(mac):
+    parts = (mac or "").replace("-", ":").split(":")
+    if len(parts) != 6:
+        return None
+    try:
+        return bytes(int(part, 16) for part in parts)
+    except ValueError:
+        return None
+
+
+def is_locally_administered_mac(mac):
+    raw = mac_bytes(mac)
+    return bool(raw and raw[0] & 0x02)
+
+
+class ManufVendorDB:
+    _entries = None
+
+    @classmethod
+    def entries(cls):
+        if cls._entries is None:
+            cls._entries = cls.load_entries()
+        return cls._entries
+
+    @classmethod
+    def load_entries(cls):
+        entries = []
+        for path in MANUF_PATHS:
+            if not os.path.exists(path):
+                continue
+            try:
+                with open(path, encoding="utf-8") as manuf_file:
+                    for line in manuf_file:
+                        entry = cls.parse_line(line)
+                        if entry:
+                            entries.append(entry)
+            except OSError as exc:
+                LOGGER.debug("Failed reading manuf database %s: %s", path, exc)
+            if entries:
+                break
+        return sorted(entries, key=lambda item: item[1], reverse=True)
+
+    @staticmethod
+    def parse_line(line):
+        line = line.strip()
+        if not line or line.startswith("#"):
+            return None
+        parts = line.split(None, 2)
+        if len(parts) < 2:
+            return None
+        prefix_text = parts[0]
+        vendor = parts[2].strip() if len(parts) > 2 else parts[1].strip()
+        if not vendor:
+            return None
+        if "/" in prefix_text:
+            prefix_text, bits_text = prefix_text.split("/", 1)
+            try:
+                prefix_bits = int(bits_text)
+            except ValueError:
+                return None
+        else:
+            prefix_bits = len(prefix_text.replace(":", "").replace("-", "")) * 4
+        try:
+            prefix_value = int(prefix_text.replace(":", "").replace("-", ""), 16)
+        except ValueError:
+            return None
+        prefix_hex_bits = len(prefix_text.replace(":", "").replace("-", "")) * 4
+        if prefix_hex_bits > prefix_bits:
+            prefix_value >>= prefix_hex_bits - prefix_bits
+        return prefix_value, prefix_bits, vendor
+
+    @classmethod
+    def lookup(cls, mac):
+        raw = mac_bytes(mac)
+        if not raw or is_locally_administered_mac(mac):
+            return ""
+        mac_value = int.from_bytes(raw, "big")
+        for prefix_value, prefix_bits, vendor in sorted(
+            cls.entries(),
+            key=lambda item: item[1],
+            reverse=True,
+        ):
+            shift = 48 - prefix_bits
+            if shift < 0:
+                continue
+            if (mac_value >> shift) == prefix_value:
+                return vendor
+        return ""
+
+
+def manuf_vendor(mac):
+    return ManufVendorDB.lookup(mac)
+
+
+def dns_encode_name(name):
+    encoded = bytearray()
+    for label in name.strip(".").split("."):
+        label_bytes = label.encode("ascii", "ignore")[:63]
+        encoded.append(len(label_bytes))
+        encoded.extend(label_bytes)
+    encoded.append(0)
+    return bytes(encoded)
+
+
+def dns_query_packet(name, query_type=12, query_id=None):
+    query_id = random.randint(1, 65535) if query_id is None else query_id
+    header = struct.pack("!HHHHHH", query_id, 0, 1, 0, 0, 0)
+    question = dns_encode_name(name) + struct.pack("!HH", query_type, 1)
+    return header + question
+
+
+def dns_read_name(packet, offset):
+    labels = []
+    jumped = False
+    end_offset = offset
+    seen_offsets = set()
+
+    while offset < len(packet):
+        length = packet[offset]
+        if length == 0:
+            offset += 1
+            if not jumped:
+                end_offset = offset
+            break
+        if length & 0xC0 == 0xC0:
+            if offset + 1 >= len(packet):
+                break
+            pointer = ((length & 0x3F) << 8) | packet[offset + 1]
+            if pointer in seen_offsets:
+                break
+            seen_offsets.add(pointer)
+            if not jumped:
+                end_offset = offset + 2
+            offset = pointer
+            jumped = True
+            continue
+        offset += 1
+        label = packet[offset : offset + length].decode("utf-8", "ignore")
+        labels.append(label)
+        offset += length
+        if not jumped:
+            end_offset = offset
+
+    return ".".join(label for label in labels if label), end_offset
+
+
+def dns_ptr_names(packet):
+    if len(packet) < 12:
+        return []
+    try:
+        qdcount, ancount, nscount, arcount = struct.unpack("!HHHH", packet[4:12])
+    except struct.error:
+        return []
+    offset = 12
+    for _ in range(qdcount):
+        _, offset = dns_read_name(packet, offset)
+        offset += 4
+    names = []
+    for _ in range(ancount + nscount + arcount):
+        _, offset = dns_read_name(packet, offset)
+        if offset + 10 > len(packet):
+            break
+        record_type, _, _, rdlength = struct.unpack("!HHIH", packet[offset : offset + 10])
+        offset += 10
+        rdata_offset = offset
+        offset += rdlength
+        if record_type == 12:
+            name, _ = dns_read_name(packet, rdata_offset)
+            if name:
+                names.append(name)
+    return names
+
+
+def reverse_dns_name(ip):
+    try:
+        address = ipaddress.ip_address(ip)
+    except ValueError:
+        return ""
+    if address.version != 4:
+        return ""
+    return ".".join(reversed(ip.split("."))) + ".in-addr.arpa"
+
+
+def udp_exchange(packet, address, port, timeout):
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+        sock.settimeout(timeout)
+        sock.sendto(packet, (address, port))
+        response, _ = sock.recvfrom(2048)
+        return response
+
+
+def mdns_reverse_hostname(ip):
+    name = reverse_dns_name(ip)
+    if not name:
+        return ""
+    packet = dns_query_packet(name, query_type=12, query_id=0)
+    responses = []
+    for address in ("224.0.0.251", ip):
+        try:
+            responses.append(udp_exchange(packet, address, 5353, 0.7))
+        except OSError as exc:
+            LOGGER.debug("mDNS reverse lookup failed for %s via %s: %s", ip, address, exc)
+    for response in responses:
+        for ptr_name in dns_ptr_names(response):
+            cleaned = clean_hostname(ptr_name)
+            if cleaned:
+                return cleaned
+    return ""
+
+
+def netbios_hostname(ip):
+    transaction_id = random.randint(1, 65535)
+    encoded_star = b" CKAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\x00"
+    packet = (
+        struct.pack("!HHHHHH", transaction_id, 0, 1, 0, 0, 0)
+        + encoded_star
+        + struct.pack("!HH", 0x0021, 0x0001)
+    )
+    try:
+        response = udp_exchange(packet, ip, 137, 0.7)
+    except OSError as exc:
+        LOGGER.debug("NetBIOS hostname lookup failed for %s: %s", ip, exc)
+        return ""
+    if len(response) < 57:
+        return ""
+    name_count = response[56]
+    offset = 57
+    for _ in range(name_count):
+        if offset + 18 > len(response):
+            break
+        raw_name = response[offset : offset + 15].decode("ascii", "ignore").strip()
+        suffix = response[offset + 15]
+        flags = struct.unpack("!H", response[offset + 16 : offset + 18])[0]
+        offset += 18
+        is_group = bool(flags & 0x8000)
+        if raw_name and raw_name != "*" and suffix in (0x00, 0x20) and not is_group:
+            return clean_hostname(raw_name)
+    return ""
+
+
 def get_hostname(ip):
+    lookup_steps = (
+        reverse_dns_hostname,
+        mdns_reverse_hostname,
+        netbios_hostname,
+    )
+    for lookup in lookup_steps:
+        hostname = lookup(ip)
+        if hostname:
+            return hostname
+    return ""
+
+
+def reverse_dns_hostname(ip):
     try:
         hostname, _, _ = socket.gethostbyaddr(ip)
         return clean_hostname(hostname)
     except (socket.herror, socket.gaierror, TimeoutError, OSError) as e:
-        LOGGER.debug("Hostname lookup failed for %s: %s", ip, e)
+        LOGGER.debug("Reverse DNS hostname lookup failed for %s: %s", ip, e)
         return ""
 
 
@@ -662,7 +934,7 @@ def sync_discovered_device(element, oui=None, scan_run=None, scan_started_at=Non
     ip = element[1].psrc
     mac = element[1].hwsrc.lower()
     vendor = ManufDA.lookup(oui, mac) if oui else None
-    vendor_name = vendor[1] if vendor else ""
+    vendor_name = manuf_vendor(mac) or (vendor[1] if vendor else "")
     hostname = get_hostname(ip=ip)
     ports_opened = 0
     ports_closed = 0

--- a/backend/core/tests.py
+++ b/backend/core/tests.py
@@ -22,6 +22,7 @@ from .models import (
     ScanRun,
 )
 from .notifications import notify_event, retry_failed_notifications
+from .views import parse_inventory_datetime
 from .scan import (
     clear_stale_gateways,
     create_event,
@@ -30,7 +31,9 @@ from .scan import (
     discover_devices,
     guess_device_identity,
     get_hostname,
+    ManufVendorDB,
     mark_missing_devices_offline,
+    manuf_vendor,
     normalize_scan_ports,
     preferred_vendor,
     sync_discovered_device,
@@ -78,9 +81,40 @@ class HostnameResolutionTests(SimpleTestCase):
     def test_clean_hostname_returns_blank_when_unavailable(self):
         self.assertEqual(clean_hostname(""), "")
 
+    @patch("core.scan.netbios_hostname", return_value="")
+    @patch("core.scan.mdns_reverse_hostname", return_value="")
     @patch("core.scan.socket.gethostbyaddr", side_effect=socket.herror)
-    def test_get_hostname_returns_blank_when_reverse_dns_is_unavailable(self, _):
+    def test_get_hostname_returns_blank_when_reverse_dns_is_unavailable(self, *_):
         self.assertEqual(get_hostname("192.168.1.10"), "")
+
+    @patch("core.scan.netbios_hostname", return_value="")
+    @patch("core.scan.mdns_reverse_hostname", return_value="haa switch")
+    @patch("core.scan.socket.gethostbyaddr", side_effect=socket.herror)
+    def test_get_hostname_uses_mdns_fallback(self, *_):
+        self.assertEqual(get_hostname("192.168.1.21"), "haa switch")
+
+    def test_manuf_parser_preserves_original_vendor_name(self):
+        entry = ManufVendorDB.parse_line(
+            "70:B3:D5:0D:00:00/36 ProHound ProHound Controles Eirelli"
+        )
+
+        self.assertEqual(entry, (0x70B3D50D0, 36, "ProHound Controles Eirelli"))
+
+    @patch("core.scan.ManufVendorDB.entries", return_value=[
+        (0x70B3D5, 24, "Generic 24-bit Vendor"),
+        (0x70B3D50D0, 36, "Specific 36-bit Vendor"),
+    ])
+    def test_manuf_vendor_prefers_more_specific_prefix(self, _):
+        self.assertEqual(manuf_vendor("70:b3:d5:0d:04:01"), "Specific 36-bit Vendor")
+
+    def test_manuf_vendor_uses_bundled_database(self):
+        self.assertEqual(
+            manuf_vendor("bc:5e:33:b0:02:04"),
+            "Hangzhou Hikvision Digital Technology Co.,Ltd.",
+        )
+
+    def test_manuf_vendor_ignores_locally_administered_mac(self):
+        self.assertEqual(manuf_vendor("f6:34:f0:00:c6:8d"), "")
 
 
 class ApiDocsAccessTests(SimpleTestCase):
@@ -1644,6 +1678,98 @@ class ScanApiTests(TestCase):
             [80, 443],
         )
 
+    def test_device_inventory_import_updates_existing_device_room(self):
+        response = self.client.post(
+            "/api/v1/devices/import/",
+            {
+                "format": "languard-device-inventory",
+                "version": 1,
+                "devices": [
+                    {
+                        "name": "Laptop",
+                        "ip": "192.168.1.10",
+                        "mac": "aa:aa:aa:aa:aa:aa",
+                        "roomName": "Office",
+                    }
+                ],
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.device.refresh_from_db()
+        self.assertEqual(self.device.room, "Office")
+
+    def test_device_inventory_import_preserves_existing_room_when_missing(self):
+        self.device.room = "Living Room"
+        self.device.save(update_fields=["room"])
+
+        response = self.client.post(
+            "/api/v1/devices/import/",
+            {
+                "format": "languard-device-inventory",
+                "version": 1,
+                "devices": [
+                    {
+                        "name": "Laptop",
+                        "ip": "192.168.1.10",
+                        "mac": "aa:aa:aa:aa:aa:aa",
+                    }
+                ],
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.device.refresh_from_db()
+        self.assertEqual(self.device.room, "Living Room")
+
+    def test_device_inventory_import_updates_existing_device_role(self):
+        response = self.client.post(
+            "/api/v1/devices/import/",
+            {
+                "format": "languard-device-inventory",
+                "version": 1,
+                "devices": [
+                    {
+                        "name": "Laptop",
+                        "ip": "192.168.1.10",
+                        "mac": "aa:aa:aa:aa:aa:aa",
+                        "deviceRole": "meshRouter",
+                    }
+                ],
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.device.refresh_from_db()
+        self.assertEqual(self.device.role, "meshRouter")
+
+    def test_device_inventory_import_preserves_existing_role_when_missing(self):
+        self.device.role = "camera"
+        self.device.save(update_fields=["role"])
+
+        response = self.client.post(
+            "/api/v1/devices/import/",
+            {
+                "format": "languard-device-inventory",
+                "version": 1,
+                "devices": [
+                    {
+                        "name": "Laptop",
+                        "ip": "192.168.1.10",
+                        "mac": "aa:aa:aa:aa:aa:aa",
+                    }
+                ],
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.device.refresh_from_db()
+        self.assertEqual(self.device.role, "camera")
+
     def test_device_inventory_import_creates_new_device(self):
         response = self.client.post(
             "/api/v1/devices/import/",
@@ -1711,6 +1837,107 @@ class ScanApiTests(TestCase):
             list(imported.ports.filter(open=True).values_list("port", flat=True)),
             [80, 443],
         )
+
+    def test_device_inventory_import_preserves_macos_export_fields(self):
+        response = self.client.post(
+            "/api/v1/devices/import/",
+            {
+                "format": "languard-device-inventory",
+                "version": 1,
+                "exported_at": 790000000,
+                "devices": [
+                    {
+                        "name": "Office Router",
+                        "ip": "192.168.1.1",
+                        "mac": "AA-BB-CC-DD-EE-10",
+                        "vendor": "TP-Link Technologies Co., Ltd.",
+                        "hostname": "office-router.local",
+                        "icon": "wifi.router",
+                        "secondary_icon": "server.rack",
+                        "role": "meshRouter",
+                        "room": "Office",
+                        "known": True,
+                        "is_gateway": True,
+                        "status": "online",
+                        "risk": "medium",
+                        "open_ports": [22, 80, "443", 80],
+                        "first_seen": 790000000,
+                        "last_seen": 790000060,
+                    }
+                ],
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        imported = Device.objects.get(mac="aa:bb:cc:dd:ee:10")
+        self.assertEqual(imported.name, "Office Router")
+        self.assertEqual(imported.ip, "192.168.1.1")
+        self.assertEqual(imported.vendor, "TP-Link Technologies Co., Ltd.")
+        self.assertEqual(imported.hostname, "office-router.local")
+        self.assertEqual(imported.icon, "router")
+        self.assertEqual(imported.secondary_icon, "server")
+        self.assertEqual(imported.role, "meshRouter")
+        self.assertEqual(imported.room, "Office")
+        self.assertTrue(imported.known)
+        self.assertTrue(imported.is_gateway)
+        self.assertTrue(imported.online)
+        self.assertEqual(imported.status, Device.Status.ONLINE)
+        self.assertEqual(imported.firstseen, parse_inventory_datetime(790000000, timezone.now()))
+        self.assertEqual(imported.lastseen, parse_inventory_datetime(790000060, timezone.now()))
+        self.assertEqual(
+            list(imported.ports.filter(open=True).values_list("port", flat=True)),
+            [22, 80, 443],
+        )
+
+    def test_device_inventory_import_maps_macos_icon_catalog(self):
+        response = self.client.post(
+            "/api/v1/devices/import/",
+            {
+                "format": "languard-device-inventory",
+                "version": 1,
+                "devices": [
+                    {
+                        "name": "Speaker",
+                        "ip": "192.168.1.71",
+                        "mac": "aa:bb:cc:dd:ee:01",
+                        "icon": "hifispeaker",
+                        "known": True,
+                    },
+                    {
+                        "name": "Switch",
+                        "ip": "192.168.1.72",
+                        "mac": "aa:bb:cc:dd:ee:02",
+                        "icon": "lightswitch.on",
+                        "secondary_icon": "powerplug",
+                        "known": True,
+                    },
+                    {
+                        "name": "Controller",
+                        "ip": "192.168.1.73",
+                        "mac": "aa:bb:cc:dd:ee:03",
+                        "icon": "switch.2",
+                        "known": True,
+                    },
+                    {
+                        "name": "Unknown Symbol",
+                        "ip": "192.168.1.74",
+                        "mac": "aa:bb:cc:dd:ee:04",
+                        "icon": "not.a.real.symbol",
+                        "known": True,
+                    },
+                ],
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(Device.objects.get(mac="aa:bb:cc:dd:ee:01").icon, "speaker")
+        switch = Device.objects.get(mac="aa:bb:cc:dd:ee:02")
+        self.assertEqual(switch.icon, "light")
+        self.assertEqual(switch.secondary_icon, "power-strip")
+        self.assertEqual(Device.objects.get(mac="aa:bb:cc:dd:ee:03").icon, "smart-hub")
+        self.assertEqual(Device.objects.get(mac="aa:bb:cc:dd:ee:04").icon, "unknown")
 
     def test_scan_runs_endpoint_returns_history(self):
         response = self.client.get("/api/v1/scan/runs/")

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -87,7 +87,26 @@ DOCKER_TO_MAC_ICON_ALIASES = {
     "power-strip": "poweroutlet.strip",
     "server": "server.rack",
 }
-MAC_TO_DOCKER_ICON_ALIASES = {value: key for key, value in DOCKER_TO_MAC_ICON_ALIASES.items()}
+DOCKER_ICON_VALUES = set(DOCKER_TO_MAC_ICON_ALIASES)
+MAC_TO_DOCKER_ICON_ALIASES = {
+    **{value: key for key, value in DOCKER_TO_MAC_ICON_ALIASES.items()},
+    "airplayvideo": "streamer",
+    "blinds.horizontal.closed": "shutter",
+    "cpu": "smart-hub",
+    "hifispeaker": "speaker",
+    "lamp.ceiling": "ceiling-light",
+    "light.panel": "light",
+    "light.recessed": "ceiling-light",
+    "lightbulb.max": "light",
+    "lightswitch.on": "light",
+    "point.3.connected.trianglepath.dotted": "smart-hub",
+    "poweroutlet.type.h": "power-strip",
+    "powerplug": "power-strip",
+    "sensor.tag.radiowaves.forward": "smart-hub",
+    "switch.2": "smart-hub",
+    "video.doorbell": "security-camera",
+    "window.shade.closed": "blinds",
+}
 
 
 def export_inventory_icon(icon):
@@ -97,12 +116,35 @@ def export_inventory_icon(icon):
 
 def import_inventory_icon(icon, fallback="unknown"):
     value = str(icon or "").strip()
-    return (MAC_TO_DOCKER_ICON_ALIASES.get(value, value)[:255] or fallback)
+    normalized = MAC_TO_DOCKER_ICON_ALIASES.get(value, value)
+    if normalized in DOCKER_ICON_VALUES:
+        return normalized
+    return fallback
+
+
+INVENTORY_ROOM_FIELDS = ("room", "roomName", "room_name", "deviceRoom", "device_room")
+INVENTORY_ROLE_FIELDS = ("role", "deviceRole", "device_role", "effectiveRole", "effective_role")
+
+
+def import_inventory_room(item):
+    for field in INVENTORY_ROOM_FIELDS:
+        if field in item:
+            return str(item.get(field) or "").strip()[:100]
+    return None
+
+
+def import_inventory_role(item):
+    for field in INVENTORY_ROLE_FIELDS:
+        if field in item:
+            return str(item.get(field) or "").strip()[:32]
+    return None
 
 
 DEVICE_ORDERING_FIELDS = {
     "name": ("name", "ip", "id"),
     "-name": ("-name", "ip", "id"),
+    "lastseen": ("lastseen", "ip", "id"),
+    "-lastseen": ("-lastseen", "ip", "id"),
 }
 
 
@@ -346,8 +388,8 @@ def import_inventory_devices(payload):
         name = str(item.get("name") or "Device").strip()[:100] or "Device"
         hostname = str(item.get("hostname") or item.get("hostName") or "").strip()[:255]
         is_gateway = parse_inventory_bool(item.get("is_gateway", item.get("isGateway", False)))
-        role = str(item.get("role") or ("gateway" if is_gateway else "device")).strip()[:32] or "device"
-        room = str(item.get("room") or "").strip()[:100]
+        role = import_inventory_role(item)
+        room = import_inventory_room(item)
         first_seen = parse_inventory_datetime(
             item.get("first_seen") or item.get("firstSeen"),
             now,
@@ -371,19 +413,23 @@ def import_inventory_devices(payload):
                 "",
             ),
             "hostname": hostname,
-            "role": role,
-            "room": room,
             "known": parse_inventory_bool(item.get("known", item.get("isKnown", False))),
             "is_gateway": is_gateway,
             "online": device_status != Device.Status.OFFLINE,
             "status": device_status,
             "lastseen": last_seen,
         }
+        if role is not None:
+            defaults["role"] = role or ("gateway" if is_gateway else "device")
+        if room is not None:
+            defaults["room"] = room
 
         device, was_created = Device.objects.get_or_create(
             mac=mac,
             defaults={
                 **defaults,
+                "role": role or ("gateway" if is_gateway else "device"),
+                "room": room or "",
                 "firstseen": first_seen,
             },
         )
@@ -400,8 +446,8 @@ def import_inventory_devices(payload):
                     "icon",
                     "secondary_icon",
                     "hostname",
-                    "role",
-                    "room",
+                    *(['role'] if role is not None else []),
+                    *(['room'] if room is not None else []),
                     "known",
                     "is_gateway",
                     "online",

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -192,6 +192,10 @@ textarea {
   flex: 0 0 auto;
 }
 
+.topbar-scan-button {
+  flex: 0 0 auto;
+}
+
 .version-pill {
   align-items: center;
   background: var(--muted-panel-bg);
@@ -247,10 +251,189 @@ textarea {
   flex: 0 0 auto;
 }
 
-.metric-card,
 .content-panel {
   border: 1px solid var(--border-color);
   background: var(--panel-bg);
+}
+
+.dashboard-summary-card,
+.content-panel {
+  border: 1px solid var(--border-color);
+  background: var(--panel-bg);
+}
+
+.dashboard-status-grid {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: repeat(4, minmax(160px, 1fr));
+}
+
+.dashboard-status-card {
+  align-items: center;
+  background: var(--panel-bg);
+  border: 1px solid var(--border-color);
+  display: flex;
+  gap: 18px;
+  min-height: 126px;
+  min-width: 0;
+  padding: 22px;
+}
+
+.dashboard-status-icon {
+  align-items: center;
+  border-radius: 14px;
+  display: inline-flex;
+  flex: 0 0 auto;
+  height: 56px;
+  justify-content: center;
+  width: 56px;
+}
+
+.dashboard-status-icon.blue {
+  background: rgba(34, 139, 230, 0.18);
+  color: #228be6;
+}
+
+.dashboard-status-icon.green {
+  background: rgba(64, 192, 87, 0.18);
+  color: #40c057;
+}
+
+.dashboard-status-icon.orange {
+  background: rgba(253, 126, 20, 0.18);
+  color: #fd7e14;
+}
+
+.dashboard-status-icon.purple {
+  background: rgba(218, 56, 255, 0.18);
+  color: #da38ff;
+}
+
+.dashboard-status-label {
+  color: var(--muted-text);
+  font-size: 1.05rem;
+  line-height: 1.1;
+}
+
+.dashboard-status-value {
+  color: var(--app-text);
+  font-size: clamp(2.25rem, 4vw, 3.25rem);
+  letter-spacing: 0;
+  line-height: 1.02;
+}
+
+.dashboard-summary-grid {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: minmax(280px, 1.1fr) minmax(240px, 1fr) minmax(280px, 1fr);
+}
+
+.dashboard-summary-card {
+  min-height: 176px;
+  overflow: hidden;
+  padding: 22px;
+}
+
+.dashboard-status-badge {
+  font-size: 0.95rem;
+  min-height: 32px;
+  padding-inline: 14px;
+}
+
+.network-health-meter {
+  background: var(--muted-panel-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  height: 12px;
+  overflow: hidden;
+}
+
+.network-health-meter-fill {
+  border-radius: inherit;
+  height: 100%;
+}
+
+.network-health-meter-fill.teal {
+  background: var(--mantine-color-teal-6);
+}
+
+.network-health-meter-fill.orange {
+  background: var(--mantine-color-orange-6);
+}
+
+.dashboard-summary-value {
+  overflow-wrap: anywhere;
+}
+
+.dashboard-insight-grid {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.dashboard-insight-card {
+  background: var(--panel-bg);
+  border: 1px solid var(--border-color);
+  min-height: 246px;
+  overflow: hidden;
+  padding: 22px;
+}
+
+.dashboard-insight-count {
+  border-radius: 999px;
+  font-size: 0.95rem;
+  min-height: 34px;
+  min-width: 44px;
+  padding-inline: 14px;
+}
+
+.dashboard-insight-row {
+  align-items: center;
+  display: grid;
+  gap: 14px;
+  grid-template-columns: 34px minmax(0, 1fr) auto;
+  min-height: 50px;
+  width: 100%;
+}
+
+.dashboard-insight-button {
+  background: transparent;
+  border: 0;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  padding: 0;
+  text-align: left;
+}
+
+.dashboard-insight-button:hover .dashboard-insight-row-body {
+  color: var(--mantine-color-blue-6);
+}
+
+.dashboard-insight-row-icon {
+  align-items: center;
+  border-radius: 999px;
+  display: inline-flex;
+  height: 34px;
+  justify-content: center;
+  width: 34px;
+}
+
+.dashboard-insight-row-icon.blue {
+  color: var(--mantine-color-blue-6);
+}
+
+.dashboard-insight-row-icon.orange {
+  color: var(--mantine-color-orange-6);
+}
+
+.dashboard-insight-row-body {
+  min-width: 0;
+}
+
+.dashboard-insight-risk {
+  justify-self: end;
+  min-width: 64px;
 }
 
 .content-panel {
@@ -259,6 +442,73 @@ textarea {
 
 .device-row:hover {
   background: var(--hover-bg);
+}
+
+.device-list-toolbar {
+  background: color-mix(in srgb, var(--muted-panel-bg) 72%, transparent);
+}
+
+.device-list {
+  max-height: min(760px, 72vh);
+  overflow-y: auto;
+}
+
+.device-list-row {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  border-top: 1px solid var(--border-color);
+  color: var(--field-text);
+  cursor: pointer;
+  display: grid;
+  gap: 16px;
+  grid-template-columns: minmax(250px, 1.25fr) minmax(520px, 2fr);
+  letter-spacing: 0;
+  min-width: 0;
+  padding: 14px 18px;
+  text-align: left;
+  width: 100%;
+}
+
+.device-list-row:hover {
+  background: var(--hover-bg);
+}
+
+.device-list-primary,
+.device-list-title {
+  min-width: 0;
+}
+
+.device-list-icon {
+  align-items: center;
+  background: var(--brand-soft);
+  border: 1px solid var(--soft-border-color);
+  border-radius: 10px;
+  color: var(--brand-strong);
+  display: inline-flex;
+  flex: 0 0 auto;
+  height: 44px;
+  justify-content: center;
+  width: 44px;
+}
+
+.device-list-meta {
+  align-items: center;
+  display: grid;
+  gap: 12px;
+  grid-template-columns:
+    minmax(96px, 0.85fr)
+    minmax(110px, 0.9fr)
+    minmax(90px, 0.75fr)
+    minmax(100px, 0.85fr)
+    minmax(84px, 0.75fr)
+    minmax(80px, 0.7fr)
+    minmax(150px, 1fr);
+  min-width: 0;
+}
+
+.device-list-meta > * {
+  min-width: 0;
 }
 
 .devices-table {
@@ -414,24 +664,55 @@ textarea {
   overflow: hidden;
 }
 
+.rooms-map-panel {
+  background: var(--panel-strong-bg);
+  border: 1px solid var(--border-color);
+  overflow: hidden;
+}
+
 .network-map {
   padding: 18px;
 }
 
-.network-map-core {
-  align-items: center;
+.rooms-map {
+  padding: 18px;
+}
+
+.rooms-map-grid {
   display: grid;
-  gap: 14px;
-  grid-template-columns: minmax(150px, 0.8fr) minmax(48px, 0.22fr) minmax(180px, 1fr);
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
 }
 
-.network-map-router-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
+.rooms-map-room {
+  background: var(--muted-panel-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  min-width: 0;
+  padding: 14px;
 }
 
-.network-map-node,
+.rooms-map-title {
+  min-width: 0;
+}
+
+.rooms-map-icon {
+  align-items: center;
+  color: var(--brand-strong);
+  display: inline-flex;
+  flex: 0 0 auto;
+}
+
+.rooms-map-room-name {
+  overflow: hidden;
+  overflow-wrap: anywhere;
+  text-overflow: ellipsis;
+}
+
+.rooms-map-room .network-device-grid {
+  grid-template-columns: repeat(auto-fill, minmax(170px, 1fr));
+}
+
 .network-device-node {
   background: var(--input-panel-bg);
   border: 1px solid var(--border-color);
@@ -441,47 +722,8 @@ textarea {
   text-align: left;
 }
 
-.network-map-node {
-  align-items: center;
-  display: grid;
-  justify-items: center;
-  min-height: 138px;
-  padding: 16px;
-}
-
-.network-map-router {
-  border-color: var(--brand);
-  clip-path: polygon(10% 0, 90% 0, 100% 50%, 90% 100%, 10% 100%, 0 50%);
-  cursor: pointer;
-  flex: 1 1 190px;
-}
-
-.network-map-internet {
-  border-radius: 999px;
-}
-
-.network-map-node-icon,
 .network-device-icon {
   color: var(--brand-strong);
-}
-
-.network-map-link,
-.network-map-branch {
-  background: linear-gradient(90deg, transparent, var(--brand), transparent);
-  min-height: 2px;
-}
-
-.network-map-branch {
-  margin: 18px auto;
-  max-width: 86%;
-}
-
-.network-map-device-section {
-  margin-top: 16px;
-}
-
-.network-map-device-section:first-of-type {
-  margin-top: 0;
 }
 
 .network-device-grid {
@@ -503,8 +745,7 @@ textarea {
   padding: 12px;
 }
 
-.network-device-node:hover,
-.network-map-router:hover {
+.network-device-node:hover {
   background: var(--hover-bg);
 }
 
@@ -720,6 +961,23 @@ textarea {
     max-width: 112px;
   }
 
+  .dashboard-status-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .dashboard-status-card {
+    min-height: 112px;
+    padding: 18px;
+  }
+
+  .dashboard-summary-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .dashboard-insight-grid {
+    grid-template-columns: 1fr;
+  }
+
   .devices-panel-header {
     align-items: stretch;
     gap: 12px;
@@ -745,6 +1003,11 @@ textarea {
     display: none;
   }
 
+  .device-list,
+  .device-list-toolbar {
+    display: none;
+  }
+
   .device-mobile-list {
     display: flex;
   }
@@ -766,41 +1029,17 @@ textarea {
     gap: 12px;
   }
 
-  .devices-pagination .mantine-Pagination-root {
-    max-width: 100%;
-    overflow-x: auto;
-    padding-bottom: 2px;
-  }
-
-  .network-map {
-    padding: 12px;
-  }
-
-  .network-map-core {
-    grid-template-columns: 1fr;
-  }
-
-  .network-map-link {
-    background: linear-gradient(180deg, transparent, var(--brand), transparent);
-    height: 34px;
-    justify-self: center;
-    min-height: 34px;
-    width: 2px;
-  }
-
-  .network-map-router-row {
-    flex-direction: column;
-  }
-
-  .network-map-router {
-    flex-basis: auto;
-  }
-
   .network-device-grid {
     grid-template-columns: 1fr;
   }
 
   .network-device-grid.featured {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 560px) {
+  .dashboard-status-grid {
     grid-template-columns: 1fr;
   }
 }

--- a/frontend/app/page.jsx
+++ b/frontend/app/page.jsx
@@ -7,7 +7,6 @@ import {
   Badge,
   Box,
   Button,
-  Card,
   Container,
   Divider,
   Group,
@@ -15,7 +14,6 @@ import {
   LoadingOverlay,
   Modal,
   NumberInput,
-  Pagination,
   Paper,
   PasswordInput,
   Select,
@@ -43,7 +41,6 @@ import {
   IconBulb,
   IconCast,
   IconClock,
-  IconCloudNetwork,
   IconDeviceCctv,
   IconDeviceDesktop,
   IconDeviceLaptop,
@@ -62,7 +59,6 @@ import {
   IconMoon,
   IconNetwork,
   IconOutlet,
-  IconPlugConnected,
   IconPrinter,
   IconPropeller,
   IconQuestionMark,
@@ -83,7 +79,6 @@ import {
   IconUserEdit,
   IconVacuumCleaner,
   IconWifi,
-  IconWifiOff,
   IconWindmill,
   IconWindow,
   IconX,
@@ -123,6 +118,13 @@ function buildVersionCheckInterval(value, unit) {
   return normalizedValue * (unit === 'hours' ? 3600 : 60);
 }
 
+function formatRoleLabel(value) {
+  return String(value || 'device')
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[-_]+/g, ' ')
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
 const eventTypeOptions = [
   { value: 'new_device', label: 'New devices' },
   { value: 'device_online', label: 'Online events' },
@@ -131,17 +133,44 @@ const eventTypeOptions = [
   { value: 'port_closed', label: 'Closed ports' },
 ];
 
-const devicePageSizeOptions = ['10', '25', '50', '100'];
-
 const deviceStatusOptions = [
   { value: 'online', label: 'Online' },
   { value: 'offline', label: 'Offline' },
   { value: 'new', label: 'New devices' },
 ];
 
+const deviceRoleOptions = [
+  'device',
+  'gateway',
+  'router',
+  'meshRouter',
+  'hub',
+  'camera',
+  'computer',
+  'server',
+  'phone',
+  'tablet',
+  'tv',
+  'streamer',
+  'printer',
+  'speaker',
+  'light',
+  'climate',
+  'smartPlug',
+  'controller',
+  'lock',
+  'intercom',
+  'sensor',
+  'robotVacuum',
+  'watch',
+  'unknown',
+  'other',
+];
+
 const inventoryViewOptions = [
-  { value: 'table', label: 'Table' },
-  { value: 'map', label: 'Map' },
+  { value: 'table', label: 'List' },
+  { value: 'rooms', label: 'Rooms' },
+  { value: 'roles', label: 'Roles' },
 ];
 
 const fallbackTimeZoneOptions = [
@@ -253,6 +282,7 @@ function normalizeDeviceIcon(value) {
     plus: 'unknown',
     device: 'desktop',
     computer: 'desktop',
+    desktopcomputer: 'desktop',
     hub: 'smart-hub',
     'smart-hub': 'smart-hub',
     smarthub: 'smart-hub',
@@ -260,25 +290,40 @@ function normalizeDeviceIcon(value) {
     smarthome: 'smart-hub',
     aqara: 'smart-hub',
     aqura: 'smart-hub',
+    cpu: 'smart-hub',
+    'point.3.connected.trianglepath.dotted': 'smart-hub',
+    'sensor.tag.radiowaves.forward': 'smart-hub',
+    'switch.2': 'smart-hub',
     mobile: 'phone',
+    iphone: 'phone',
     ipad: 'tablet',
     pad: 'tablet',
+    applewatch: 'smart-watch',
     watch: 'smart-watch',
     smartwatch: 'smart-watch',
     'smart-watch': 'smart-watch',
     wearable: 'smart-watch',
+    macbook: 'laptop',
     television: 'tv',
+    airplayvideo: 'streamer',
     cast: 'streamer',
     streaming: 'streamer',
     camera: 'security-camera',
     cctv: 'security-camera',
+    'video.doorbell': 'security-camera',
     blind: 'blinds',
+    'blinds.horizontal.closed': 'shutter',
     shade: 'blinds',
     curtain: 'blinds',
     window: 'shutter',
+    'window.shade.closed': 'blinds',
     'roller-shutter': 'shutter',
     rollershutter: 'shutter',
     bulb: 'light',
+    lightbulb: 'light',
+    'lightbulb.max': 'light',
+    'light.panel': 'light',
+    'lightswitch.on': 'light',
     led: 'led-strip',
     'led-strip': 'led-strip',
     ledstrip: 'led-strip',
@@ -286,14 +331,19 @@ function normalizeDeviceIcon(value) {
     lightstrip: 'led-strip',
     'strip-light': 'led-strip',
     striplight: 'led-strip',
+    'light.strip.2': 'led-strip',
     lamp: 'desk-lamp',
+    'lamp.desk': 'desk-lamp',
     'desk-lamp': 'desk-lamp',
     desklamp: 'desk-lamp',
     'table-lamp': 'desk-lamp',
     tablelamp: 'desk-lamp',
+    'lamp.ceiling': 'ceiling-light',
+    'light.recessed': 'ceiling-light',
     'ceiling-light': 'ceiling-light',
     ceilinglight: 'ceiling-light',
     downlight: 'ceiling-light',
+    'air.conditioner.horizontal': 'air-conditioner',
     aircon: 'air-conditioner',
     ac: 'air-conditioner',
     hvac: 'air-conditioner',
@@ -303,23 +353,35 @@ function normalizeDeviceIcon(value) {
     ceilingfan: 'ceiling-fan',
     'cilling-fan': 'ceiling-fan',
     cillingfan: 'ceiling-fan',
+    'fan.ceiling': 'ceiling-fan',
+    'thermometer.medium': 'thermostat',
     'thermometer-snow': 'thermostat',
     temperature: 'thermostat',
     audio: 'speaker',
+    hifispeaker: 'speaker',
+    homepod: 'speaker',
     security: 'lock',
     smartlock: 'lock',
     'smart-lock': 'lock',
+    lock: 'lock',
+    printer: 'printer',
     vacuum: 'robot-vacuum',
     roomba: 'robot-vacuum',
     robot: 'robot-vacuum',
+    'robotic.vacuum': 'robot-vacuum',
     'vacuum-cleaner': 'robot-vacuum',
     outlet: 'power-strip',
     socket: 'power-strip',
     plug: 'power-strip',
+    powerplug: 'power-strip',
+    'poweroutlet.strip': 'power-strip',
+    'poweroutlet.type.h': 'power-strip',
     'smart-plug': 'power-strip',
     'plug-strip': 'power-strip',
     'power-outlet': 'power-strip',
     nas: 'server',
+    'server.rack': 'server',
+    'wifi.router': 'router',
   };
   const normalized = aliases[value] || value || 'unknown';
   return deviceIconOptions.some((option) => option.value === normalized)
@@ -359,31 +421,6 @@ function deviceMapShape(device) {
   return 'device';
 }
 
-function isRouterDevice(device) {
-  if (device.is_gateway) {
-    return true;
-  }
-  const normalizedIcon = normalizeDeviceIcon(device.icon);
-  const text = `${device.name || ''} ${device.hostname || ''} ${device.vendor || ''}`.toLowerCase();
-  if (normalizedIcon === 'smart-hub' || text.includes('aqara') || text.includes('aqura')) {
-    return false;
-  }
-  return (
-    normalizedIcon === 'router' ||
-    text.includes('router') ||
-    text.includes('gateway') ||
-    text.includes('access point')
-  );
-}
-
-function isHubDevice(device) {
-  return normalizeDeviceIcon(device.icon) === 'smart-hub';
-}
-
-function isCameraDevice(device) {
-  return normalizeDeviceIcon(device.icon) === 'security-camera';
-}
-
 function NetworkMapDeviceNode({ device, onSelectDevice }) {
   const status = deviceStatus(device);
 
@@ -414,103 +451,139 @@ function NetworkMapDeviceNode({ device, onSelectDevice }) {
   );
 }
 
-function NetworkMapDeviceSection({ title, devices, onSelectDevice, compact = false }) {
-  if (!devices.length) {
-    return null;
-  }
+function getDeviceRoomLabel(device) {
+  const room = String(device.room || '').trim();
+  return room || 'Unassigned';
+}
+
+function buildRoomSections(devices) {
+  const sectionsByRoom = new Map();
+
+  devices.forEach((device) => {
+    const room = getDeviceRoomLabel(device);
+    if (!sectionsByRoom.has(room)) {
+      sectionsByRoom.set(room, []);
+    }
+    sectionsByRoom.get(room).push(device);
+  });
+
+  return Array.from(sectionsByRoom.entries())
+    .map(([room, roomDevices]) => ({
+      room,
+      devices: roomDevices.sort((left, right) =>
+        String(left.name || left.ip || '').localeCompare(String(right.name || right.ip || ''))
+      ),
+    }))
+    .sort((left, right) => {
+      if (left.room === 'Unassigned') return 1;
+      if (right.room === 'Unassigned') return -1;
+      return left.room.localeCompare(right.room);
+    });
+}
+
+function RoomsMap({ devices = [], onSelectDevice }) {
+  const roomSections = buildRoomSections(devices);
 
   return (
-    <section className="network-map-device-section">
-      <Group justify="space-between" align="center" mb="xs">
-        <Text fw={800}>{title}</Text>
-        <Badge variant="light" color="indigo">{devices.length}</Badge>
-      </Group>
-      <div className={`network-device-grid ${compact ? 'featured' : ''}`}>
-        {devices.map((device) => (
-          <NetworkMapDeviceNode key={device.id} device={device} onSelectDevice={onSelectDevice} />
-        ))}
+    <Paper className="rooms-map-panel" radius="md">
+      <div className="rooms-map">
+        {roomSections.length ? (
+          <div className="rooms-map-grid">
+            {roomSections.map((section) => (
+              <section className="rooms-map-room" key={section.room}>
+                <Group justify="space-between" align="center" mb="sm" wrap="nowrap">
+                  <Group gap="xs" wrap="nowrap" className="rooms-map-title">
+                    <span className="rooms-map-icon">
+                      <IconSmartHome size={22} />
+                    </span>
+                    <Text fw={800} className="rooms-map-room-name">{section.room}</Text>
+                  </Group>
+                  <Badge variant="light" color={section.room === 'Unassigned' ? 'gray' : 'indigo'}>
+                    {section.devices.length}
+                  </Badge>
+                </Group>
+                <div className="network-device-grid">
+                  {section.devices.map((device) => (
+                    <NetworkMapDeviceNode
+                      key={device.id}
+                      device={device}
+                      onSelectDevice={onSelectDevice}
+                    />
+                  ))}
+                </div>
+              </section>
+            ))}
+          </div>
+        ) : (
+          <Text c="dimmed" ta="center" py="xl">
+            No devices to show.
+          </Text>
+        )}
       </div>
-    </section>
+    </Paper>
   );
 }
 
-function NetworkMap({ devices = [], onSelectDevice }) {
-  const routerDevices = devices
-    .filter(isRouterDevice)
-    .sort((left, right) => Number(Boolean(right.is_gateway)) - Number(Boolean(left.is_gateway)));
-  const hubDevices = devices.filter((device) => !isRouterDevice(device) && isHubDevice(device));
-  const cameraDevices = devices.filter((device) => !isRouterDevice(device) && isCameraDevice(device));
-  const networkDevices = devices.filter(
-    (device) => !isRouterDevice(device) && !isHubDevice(device) && !isCameraDevice(device)
-  );
-  const routers = routerDevices.length
-    ? routerDevices
-    : [
-        {
-          id: 'router-placeholder',
-          name: 'Home router',
-          ip: 'Gateway',
-          icon: 'router',
-          known: true,
-          online: true,
-          open_ports: [],
-        },
-      ];
+function buildRoleSections(devices) {
+  const sectionsByRole = new Map();
+
+  devices.forEach((device) => {
+    const role = device.role || 'device';
+    const roleLabel = formatRoleLabel(role);
+    if (!sectionsByRole.has(roleLabel)) {
+      sectionsByRole.set(roleLabel, []);
+    }
+    sectionsByRole.get(roleLabel).push(device);
+  });
+
+  return Array.from(sectionsByRole.entries())
+    .map(([role, roleDevices]) => ({
+      role,
+      devices: roleDevices.sort((left, right) =>
+        String(left.name || left.ip || '').localeCompare(String(right.name || right.ip || ''))
+      ),
+    }))
+    .sort((left, right) => left.role.localeCompare(right.role));
+}
+
+function RolesMap({ devices = [], onSelectDevice }) {
+  const roleSections = buildRoleSections(devices);
 
   return (
-    <Paper className="network-map-panel" radius="md">
-      <div className="network-map">
-        <div className="network-map-core">
-          <div className="network-map-node network-map-internet">
-            <span className="network-map-node-icon">
-              <IconCloudNetwork size={30} />
-            </span>
-            <Text fw={800}>Internet</Text>
-            <Text size="xs" c="dimmed">WAN connection</Text>
-          </div>
-          <div className="network-map-link" aria-hidden="true" />
-          <div className="network-map-router-row">
-            {routers.map((router) => (
-              <button
-                type="button"
-                key={router.id}
-                className="network-map-node network-map-router"
-                onClick={() => {
-                  if (router.id !== 'router-placeholder') {
-                    onSelectDevice(router);
-                  }
-                }}
-              >
-                <span className="network-map-node-icon">
-                  <DeviceIcon value={router.icon} size={28} />
-                </span>
-                <Text fw={800} className="network-node-name">{router.name}</Text>
-                <Text size="xs" className="mobile-mono-value">{router.ip}</Text>
-                <PortSummary ports={router.open_ports || []} />
-              </button>
+    <Paper className="rooms-map-panel" radius="md">
+      <div className="rooms-map">
+        {roleSections.length ? (
+          <div className="rooms-map-grid">
+            {roleSections.map((section) => (
+              <section className="rooms-map-room" key={section.role}>
+                <Group justify="space-between" align="center" mb="sm" wrap="nowrap">
+                  <Group gap="xs" wrap="nowrap" className="rooms-map-title">
+                    <span className="rooms-map-icon">
+                      <IconNetwork size={22} />
+                    </span>
+                    <Text fw={800} className="rooms-map-room-name">{section.role}</Text>
+                  </Group>
+                  <Badge variant="light" color="indigo">
+                    {section.devices.length}
+                  </Badge>
+                </Group>
+                <div className="network-device-grid">
+                  {section.devices.map((device) => (
+                    <NetworkMapDeviceNode
+                      key={device.id}
+                      device={device}
+                      onSelectDevice={onSelectDevice}
+                    />
+                  ))}
+                </div>
+              </section>
             ))}
           </div>
-        </div>
-
-        <div className="network-map-branch" aria-hidden="true" />
-
-        <NetworkMapDeviceSection
-          title="Hubs"
-          devices={hubDevices}
-          onSelectDevice={onSelectDevice}
-          compact
-        />
-        <NetworkMapDeviceSection
-          title="Cameras"
-          devices={cameraDevices}
-          onSelectDevice={onSelectDevice}
-          compact
-        />
-        <NetworkMapDeviceSection
-          title="Devices"
-          devices={networkDevices}
-          onSelectDevice={onSelectDevice}
-        />
+        ) : (
+          <Text c="dimmed" ta="center" py="xl">
+            No devices to show.
+          </Text>
+        )}
       </div>
     </Paper>
   );
@@ -905,22 +978,6 @@ function AuthScreen({ onLogin }) {
   );
 }
 
-function MetricCard({ icon, label, value, color }) {
-  return (
-    <Card className="metric-card" radius="md" padding="lg">
-      <Group justify="space-between" align="flex-start">
-        <Stack gap={4}>
-          <Text size="sm" c="dimmed">
-            {label}
-          </Text>
-          <Title order={2}>{value ?? 0}</Title>
-        </Stack>
-        <ThemeIconLike color={color}>{icon}</ThemeIconLike>
-      </Group>
-    </Card>
-  );
-}
-
 function ThemeIconLike({ children, color }) {
   return (
     <Box
@@ -935,6 +992,277 @@ function ThemeIconLike({ children, color }) {
       }}
     >
       {children}
+    </Box>
+  );
+}
+
+function DashboardStatusCards({ counters = {} }) {
+  return (
+    <div className="dashboard-status-grid">
+      <DashboardStatusCard
+        icon={<IconDeviceDesktop size={30} />}
+        label="Devices"
+        value={counters.all_devices ?? 0}
+        color="blue"
+      />
+      <DashboardStatusCard
+        icon={<IconWifi size={30} />}
+        label="Online"
+        value={counters.online_devices ?? 0}
+        color="green"
+      />
+      <DashboardStatusCard
+        icon={<IconQuestionMark size={30} />}
+        label="Unknown"
+        value={counters.new_devices ?? 0}
+        color="orange"
+      />
+      <DashboardStatusCard
+        icon={<IconNetwork size={30} />}
+        label="Open Ports"
+        value={counters.open_ports ?? 0}
+        color="purple"
+      />
+    </div>
+  );
+}
+
+function DashboardStatusCard({ icon, label, value, color }) {
+  return (
+    <Paper className="dashboard-status-card" radius="md">
+      <span className={`dashboard-status-icon ${color}`}>
+        {icon}
+      </span>
+      <Box>
+        <Text className="dashboard-status-label" fw={800}>{label}</Text>
+        <Text className="dashboard-status-value" fw={900}>{value}</Text>
+      </Box>
+    </Paper>
+  );
+}
+
+function NetworkHealthCard({ counters = {} }) {
+  const totalDevices = Number(counters.all_devices) || 0;
+  const newDevices = Number(counters.new_devices) || 0;
+  const knownCoverage = totalDevices > 0
+    ? Math.round(((totalDevices - newDevices) / totalDevices) * 100)
+    : 100;
+  const healthColor = knownCoverage >= 95 ? 'teal' : 'orange';
+  const healthLabel = knownCoverage >= 95 ? 'Good' : 'Review';
+
+  return (
+    <Paper className="dashboard-summary-card network-health-card" radius="md">
+      <Group justify="space-between" align="center" mb="lg" wrap="nowrap">
+        <Group gap="sm" wrap="nowrap">
+          <IconLine size={28} />
+          <Title order={3}>Network Health</Title>
+        </Group>
+        <Badge className="dashboard-status-badge" color={healthColor} variant="light">
+          {healthLabel}
+        </Badge>
+      </Group>
+      <div className="network-health-meter" aria-hidden="true">
+        <div
+          className={`network-health-meter-fill ${healthColor}`}
+          style={{ width: `${Math.min(100, Math.max(0, knownCoverage))}%` }}
+        />
+      </div>
+      <Stack gap={8} mt="lg">
+        <SummaryRow label="Known coverage" value={`${knownCoverage}%`} />
+        <SummaryRow label="Online devices" value={counters.online_devices ?? 0} />
+        <SummaryRow label="Open ports" value={counters.open_ports ?? 0} />
+      </Stack>
+    </Paper>
+  );
+}
+
+function AutomaticScanningCard({ appSettings, scanVisibility }) {
+  return (
+    <Paper className="dashboard-summary-card automatic-scanning-card" radius="md">
+      <Group align="flex-start" gap="md" wrap="nowrap">
+        <ThemeIconLike color="blue">
+          <IconClock size={24} />
+        </ThemeIconLike>
+        <Box>
+          <Title order={3}>Automatic Scanning</Title>
+          <Text c="dimmed" fw={600}>Enabled</Text>
+        </Box>
+      </Group>
+      <SimpleGrid cols={2} mt="xl">
+        <SummaryMetric label="Interval" value={appSettings?.scan_interval ? `${appSettings.scan_interval} min` : '-'} />
+        <SummaryMetric label="Range" value={scanVisibility?.current_range || appSettings?.ip_range || '-'} align="right" />
+      </SimpleGrid>
+    </Paper>
+  );
+}
+
+function LatestScanCard({ scanStatus, scanVisibility, timeZone }) {
+  const statusColor = scanVisibility?.is_scanning
+    ? 'blue'
+    : scanStatus?.status === 'failed'
+      ? 'red'
+      : 'teal';
+  const statusLabel = scanVisibility?.is_scanning ? 'Scanning' : scanStatus?.status || '-';
+
+  return (
+    <Paper className="dashboard-summary-card latest-scan-card" radius="md">
+      <Group justify="space-between" align="center" mb="lg" wrap="nowrap">
+        <Group gap="sm" wrap="nowrap">
+          <IconClock size={28} />
+          <Title order={3}>Latest Scan</Title>
+        </Group>
+        <Badge className="dashboard-status-badge" color={statusColor} variant="light">
+          {statusLabel}
+        </Badge>
+      </Group>
+      <SimpleGrid cols={2}>
+        <SummaryMetric label="Devices" value={scanStatus?.devices_seen ?? 0} />
+        <SummaryMetric label="Duration" value={formatDuration(scanVisibility?.duration_seconds)} />
+        <SummaryMetric label="Started" value={formatDate(scanVisibility?.started_at, timeZone)} />
+        <SummaryMetric label="Finished" value={formatDate(scanVisibility?.finished_at, timeZone)} />
+      </SimpleGrid>
+      {scanVisibility?.last_error && (
+        <Alert mt="md" color="red" icon={<IconAlertCircle size={18} />}>
+          {scanVisibility.last_error}
+        </Alert>
+      )}
+    </Paper>
+  );
+}
+
+function DashboardInsightCards({ events = [], devices = [], onSelectDevice, timeZone }) {
+  const recentEvents = events.slice(0, 5);
+  const attentionDevices = devices
+    .filter((device) => !device.known || ['high', 'medium'].includes(device.risk_level))
+    .sort((first, second) => {
+      const riskWeight = { high: 0, medium: 1, low: 2 };
+      const firstWeight = first.known ? riskWeight[first.risk_level] ?? 2 : -1;
+      const secondWeight = second.known ? riskWeight[second.risk_level] ?? 2 : -1;
+      return firstWeight - secondWeight || String(first.ip).localeCompare(String(second.ip), undefined, { numeric: true });
+    });
+
+  return (
+    <div className="dashboard-insight-grid">
+      <Paper className="dashboard-insight-card" radius="md">
+        <DashboardInsightHeader
+          icon={<IconHistory size={26} />}
+          title="Recently Changed"
+          count={events.length}
+          color="blue"
+        />
+        <Stack gap="sm">
+          {recentEvents.length ? recentEvents.map((event) => (
+            <DashboardEventRow key={event.id} event={event} timeZone={timeZone} />
+          )) : (
+            <DashboardEmptyState label="No recent changes" />
+          )}
+        </Stack>
+      </Paper>
+
+      <Paper className="dashboard-insight-card" radius="md">
+        <DashboardInsightHeader
+          icon={<IconShieldLock size={26} />}
+          title="Needs Attention"
+          count={attentionDevices.length}
+          color="orange"
+        />
+        <Stack gap="sm">
+          {attentionDevices.slice(0, 5).map((device) => (
+            <DashboardAttentionRow
+              key={device.id}
+              device={device}
+              onSelectDevice={onSelectDevice}
+            />
+          ))}
+          {!attentionDevices.length && <DashboardEmptyState label="No devices need attention" />}
+        </Stack>
+      </Paper>
+    </div>
+  );
+}
+
+function DashboardInsightHeader({ icon, title, count, color }) {
+  return (
+    <Group justify="space-between" align="center" mb="md" wrap="nowrap">
+      <Group gap="sm" wrap="nowrap">
+        {icon}
+        <Title order={3}>{title}</Title>
+      </Group>
+      <Badge className="dashboard-insight-count" color={color} variant="light">
+        {count}
+      </Badge>
+    </Group>
+  );
+}
+
+function DashboardEventRow({ event, timeZone }) {
+  return (
+    <div className="dashboard-insight-row">
+      <span className="dashboard-insight-row-icon blue">
+        <IconHistory size={20} />
+      </span>
+      <Box className="dashboard-insight-row-body">
+        <Text fw={800} className="truncate-cell">
+          {event.message || event.event_type_display || event.event_type}
+        </Text>
+        <Text size="sm" c="dimmed" className="truncate-cell">
+          {[event.event_type_display || event.event_type, formatDate(event.created_at, timeZone)]
+            .filter(Boolean)
+            .join(' - ')}
+        </Text>
+      </Box>
+    </div>
+  );
+}
+
+function DashboardAttentionRow({ device, onSelectDevice }) {
+  const risk = deviceRisk(device);
+  const reason = !device.known ? 'Unknown device' : risk.label;
+
+  return (
+    <button
+      type="button"
+      className="dashboard-insight-row dashboard-insight-button"
+      onClick={() => onSelectDevice(device)}
+    >
+      <span className="dashboard-insight-row-icon orange">
+        <DeviceIcon value={device.icon} size={20} />
+      </span>
+      <Box className="dashboard-insight-row-body">
+        <Text fw={800} className="truncate-cell">{device.name}</Text>
+        <Text size="sm" c="dimmed" className="truncate-cell">
+          {[reason, device.ip].filter(Boolean).join(' - ')}
+        </Text>
+      </Box>
+      <Badge className="dashboard-insight-risk" color={risk.color} variant="light">
+        {risk.label}
+      </Badge>
+    </button>
+  );
+}
+
+function DashboardEmptyState({ label }) {
+  return (
+    <Text c="dimmed" fw={700} py="sm">
+      {label}
+    </Text>
+  );
+}
+
+function SummaryRow({ label, value }) {
+  return (
+    <Group justify="space-between" wrap="nowrap">
+      <Text c="dimmed" fw={600}>{label}</Text>
+      <Text fw={800}>{value}</Text>
+    </Group>
+  );
+}
+
+function SummaryMetric({ label, value, align = 'left' }) {
+  return (
+    <Box ta={align}>
+      <Text size="sm" c="dimmed" fw={600}>{label}</Text>
+      <Text className="dashboard-summary-value" fw={800}>{value}</Text>
     </Box>
   );
 }
@@ -1148,8 +1476,8 @@ function DeviceModal({ device, opened, onClose, onSaved, timeZone }) {
           <Box className="device-field">
             <Text size="xs" c="dimmed">Role</Text>
             <select className="device-field-input" value={role} onChange={(event) => setRole(event.currentTarget.value)}>
-              {['device', 'gateway', 'router', 'hub', 'camera', 'server', 'controller', 'other'].map((value) => (
-                <option key={value} value={value}>{value.replace(/-/g, ' ')}</option>
+              {deviceRoleOptions.map((value) => (
+                <option key={value} value={value}>{formatRoleLabel(value)}</option>
               ))}
             </select>
           </Box>
@@ -1944,7 +2272,7 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
   const [mapDevices, setMapDevices] = useState([]);
   const [devicePagination, setDevicePagination] = useState({
     count: 0,
-    limit: 10,
+    limit: 100,
     offset: 0,
     next_offset: null,
     previous_offset: null,
@@ -1960,12 +2288,9 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
   const [search, setSearch] = useState('');
   const [deviceStatus, setDeviceStatus] = useState('');
   const [inventoryView, setInventoryView] = useState('table');
-  const [devicePage, setDevicePage] = useState(1);
-  const [devicePageSize, setDevicePageSize] = useState('10');
   const [deviceOrdering, setDeviceOrdering] = useState('');
   const [activeTab, setActiveTab] = useState('events');
   const [eventType, setEventType] = useState('');
-  const [scanRange, setScanRange] = useState('');
   const [activeDevice, setActiveDevice] = useState(null);
   const [changelogOpened, setChangelogOpened] = useState(false);
   const [seenChangelogVersion, setSeenChangelogVersion] = useState(APP_VERSION);
@@ -1981,20 +2306,15 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
     search: '',
     deviceStatus: '',
     eventType: '',
-    deviceLimit: 10,
+    deviceLimit: 100,
     deviceOffset: 0,
     deviceOrdering: '',
   });
 
   const filteredDevices = useMemo(() => devices, [devices]);
-  const deviceLimit = Number(devicePageSize);
-  const devicePageCount = Math.max(
-    1,
-    Math.ceil((devicePagination.count || 0) / deviceLimit)
-  );
-  const deviceOffset = (devicePage - 1) * deviceLimit;
-  const deviceStart = devicePagination.count === 0 ? 0 : deviceOffset + 1;
-  const deviceEnd = Math.min(deviceOffset + devices.length, devicePagination.count);
+  const deviceLimit = 100;
+  const deviceOffset = 0;
+  const deviceEnd = Math.min(devices.length, devicePagination.count || devices.length);
   const selectedDeviceStatus =
     deviceStatusOptions.find((option) => option.value === deviceStatus) || null;
   const canManageUsers = Boolean(user?.is_staff || user?.is_superuser);
@@ -2015,7 +2335,7 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
       deviceOffset,
       deviceOrdering,
     };
-  }, [search, deviceStatus, eventType, deviceLimit, deviceOffset, deviceOrdering]);
+  }, [search, deviceStatus, eventType, deviceOrdering]);
 
   async function loadData({ quiet = false, notifyOnError = false, notifyOnSuccess = false } = {}) {
     if (quiet) {
@@ -2174,11 +2494,7 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
   useEffect(() => {
     const timer = window.setTimeout(() => loadData({ quiet: true }), 250);
     return () => window.clearTimeout(timer);
-  }, [search, deviceStatus, eventType, devicePage, devicePageSize, deviceOrdering]);
-
-  useEffect(() => {
-    setDevicePage(1);
-  }, [search, deviceStatus, devicePageSize, deviceOrdering]);
+  }, [search, deviceStatus, eventType, deviceOrdering]);
 
   async function runScan() {
     setRefreshing(true);
@@ -2186,7 +2502,7 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
     try {
       await apiRequest('scan/', {
         method: 'POST',
-        body: scanRange ? { ip_range: scanRange } : {},
+        body: {},
       });
       await loadData({ quiet: true });
       showSuccessNotification('Scan started', 'LanGuard is scanning the selected network range.');
@@ -2273,6 +2589,15 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
                 </Box>
               </Group>
               <ColorSchemeControl />
+              <Button
+                size="sm"
+                leftSection={<IconRefresh size={17} />}
+                onClick={runScan}
+                loading={refreshing}
+                className="topbar-scan-button"
+              >
+                Run Scan
+              </Button>
               {canManageUsers && (
                 <Button
                   component="a"
@@ -2339,12 +2664,27 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
             </Alert>
           )}
 
-          <SimpleGrid cols={{ base: 1, sm: 2, lg: 4 }}>
-            <MetricCard icon={<IconDeviceDesktop size={24} />} label="Inventory devices" value={counters.all_devices} color="indigo" />
-            <MetricCard icon={<IconWifi size={24} />} label="Online" value={counters.online_devices} color="teal" />
-            <MetricCard icon={<IconWifiOff size={24} />} label="Offline" value={counters.offline_devices} color="gray" />
-            <MetricCard icon={<IconPlugConnected size={24} />} label="Open ports now" value={counters.open_ports} color="orange" />
-          </SimpleGrid>
+          <DashboardStatusCards counters={counters} />
+
+          <div className="dashboard-summary-grid">
+            <NetworkHealthCard counters={counters} />
+            <AutomaticScanningCard appSettings={appSettings} scanVisibility={scanVisibility} />
+            <LatestScanCard
+              scanStatus={scanStatus}
+              scanVisibility={scanVisibility}
+              timeZone={displayTimeZone}
+            />
+          </div>
+
+          <DashboardInsightCards
+            events={events}
+            devices={mapDevices}
+            onSelectDevice={(device) => {
+              setActiveDevice(device);
+              modal.open();
+            }}
+            timeZone={displayTimeZone}
+          />
 
           <Paper className="content-panel" radius="md">
             <Stack gap={0}>
@@ -2369,13 +2709,6 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
                     aria-label={selectedDeviceStatus?.label || 'Status'}
                     onChange={(value) => setDeviceStatus(value || '')}
                   />
-                  <Select
-                    w={115}
-                    aria-label="Rows per page"
-                    data={devicePageSizeOptions}
-                    value={devicePageSize}
-                    onChange={(value) => setDevicePageSize(value || '10')}
-                  />
                   <TextInput
                     w={{ base: 180, sm: 260 }}
                     placeholder="Search"
@@ -2399,9 +2732,9 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
                 </Group>
               </Group>
               <Divider />
-              {inventoryView === 'map' ? (
+              {inventoryView === 'rooms' ? (
                 <Box p="md">
-                  <NetworkMap
+                  <RoomsMap
                     devices={mapDevices}
                     onSelectDevice={(device) => {
                       setActiveDevice(device);
@@ -2409,88 +2742,118 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
                     }}
                   />
                   <Text size="xs" c="dimmed" mt="sm">
-                    Showing up to 100 devices on the map.
+                    Showing up to 100 devices grouped by room.
+                  </Text>
+                </Box>
+              ) : inventoryView === 'roles' ? (
+                <Box p="md">
+                  <RolesMap
+                    devices={mapDevices}
+                    onSelectDevice={(device) => {
+                      setActiveDevice(device);
+                      modal.open();
+                    }}
+                  />
+                  <Text size="xs" c="dimmed" mt="sm">
+                    Showing up to 100 devices grouped by role.
                   </Text>
                 </Box>
               ) : (
                 <>
-                  <Table className="devices-table" highlightOnHover verticalSpacing="sm">
-                    <Table.Thead>
-                      <Table.Tr>
-                        <Table.Th className="device-status-cell">Status</Table.Th>
-                        <SortableHeader
-                          field="name"
-                          label="Name"
-                          ordering={deviceOrdering}
-                          onChange={setDeviceOrdering}
-                          className="device-name-cell"
-                        />
-                        <Table.Th className="device-room-cell">Room</Table.Th>
-                        <Table.Th className="device-role-cell">Role</Table.Th>
-                        <SortableHeader
-                          field="ip"
-                          label="IP"
-                          ordering={deviceOrdering}
-                          onChange={setDeviceOrdering}
-                          className="device-ip-cell"
-                        />
-                        <Table.Th className="device-mac-cell">MAC</Table.Th>
-                        <Table.Th className="device-ports-cell">Ports</Table.Th>
-                        <Table.Th className="device-risk-cell">Risk</Table.Th>
-                        <Table.Th className="device-lastseen-cell">Last seen</Table.Th>
-                        <Table.Th className="device-known-cell">Known</Table.Th>
-                      </Table.Tr>
-                    </Table.Thead>
-                    <Table.Tbody>
-                      {filteredDevices.map((device) => (
-                        <Table.Tr
-                          className="device-row"
-                          key={device.id}
-                          onClick={() => {
-                            setActiveDevice(device);
-                            modal.open();
-                          }}
-                          style={{ cursor: 'pointer' }}
+                  <Box className="device-list-toolbar" p="md">
+                    <Group justify="space-between" wrap="wrap" gap="sm">
+                      <Group gap="xs">
+                        <Button
+                          size="xs"
+                          variant={deviceOrdering === 'name' ? 'light' : 'subtle'}
+                          onClick={() => setDeviceOrdering(sortableOrdering('name', deviceOrdering))}
                         >
-                          <Table.Td className="device-status-cell">
-                            <DeviceStatusInline device={device} />
-                          </Table.Td>
-                          <Table.Td className="device-name-cell" fw={600}>
+                          Name
+                        </Button>
+                        <Button
+                          size="xs"
+                          variant={deviceOrdering === 'ip' ? 'light' : 'subtle'}
+                          onClick={() => setDeviceOrdering(sortableOrdering('ip', deviceOrdering))}
+                        >
+                          IP
+                        </Button>
+                        <Button
+                          size="xs"
+                          variant={deviceOrdering === '-lastseen' ? 'light' : 'subtle'}
+                          onClick={() => setDeviceOrdering(sortableOrdering('lastseen', deviceOrdering))}
+                        >
+                          Last seen
+                        </Button>
+                      </Group>
+                      <Text size="sm" c="dimmed">
+                        Showing {deviceEnd} of {devicePagination.count || deviceEnd} devices
+                      </Text>
+                    </Group>
+                  </Box>
+                  <Stack className="device-list" gap={0}>
+                    {filteredDevices.map((device) => (
+                      <button
+                        type="button"
+                        className="device-list-row"
+                        key={device.id}
+                        onClick={() => {
+                          setActiveDevice(device);
+                          modal.open();
+                        }}
+                      >
+                        <Group className="device-list-primary" gap="md" align="center" wrap="nowrap">
+                          <span className="device-list-icon">
+                            <DeviceIcon value={device.icon} size={22} />
+                          </span>
+                          <Box className="device-list-title">
                             <Group gap="xs" wrap="nowrap">
-                              <span className="device-table-icon">
-                                <DeviceIcon value={device.icon} size={17} />
-                              </span>
-                              <span className="truncate-cell" title={device.name}>
-                                {device.name}
-                              </span>
+                              <Text fw={800} className="truncate-cell">{device.name}</Text>
+                              <Badge
+                                className="device-known-badge"
+                                color={device.known ? 'teal' : 'yellow'}
+                                variant="light"
+                              >
+                                {device.known ? 'Known' : 'New'}
+                              </Badge>
                             </Group>
-                          </Table.Td>
-                          <Table.Td className="device-room-cell">{device.room || '-'}</Table.Td>
-                          <Table.Td className="device-role-cell">{device.role || 'device'}</Table.Td>
-                          <Table.Td className="device-ip-cell">{device.ip}</Table.Td>
-                          <Table.Td className="device-mac-cell">{device.mac}</Table.Td>
-                          <Table.Td className="device-ports-cell">
+                            <Text size="sm" c="dimmed" className="truncate-cell">
+                              {[device.hostname, device.vendor].filter(Boolean).join(' - ') || device.mac}
+                            </Text>
+                          </Box>
+                        </Group>
+                        <div className="device-list-meta">
+                          <Box>
+                            <Text size="xs" c="dimmed">Status</Text>
+                            <DeviceStatusInline device={device} muted />
+                          </Box>
+                          <Box>
+                            <Text size="xs" c="dimmed">IP</Text>
+                            <Text fw={700} className="mobile-mono-value">{device.ip}</Text>
+                          </Box>
+                          <Box>
+                            <Text size="xs" c="dimmed">Room</Text>
+                            <Text>{device.room || '-'}</Text>
+                          </Box>
+                          <Box>
+                            <Text size="xs" c="dimmed">Role</Text>
+                            <Text>{formatRoleLabel(device.role)}</Text>
+                          </Box>
+                          <Box>
+                            <Text size="xs" c="dimmed">Ports</Text>
                             <PortSummary ports={device.open_ports || []} />
-                          </Table.Td>
-                          <Table.Td className="device-risk-cell">
+                          </Box>
+                          <Box>
+                            <Text size="xs" c="dimmed">Risk</Text>
                             <RiskBadge device={device} compact />
-                          </Table.Td>
-                          <Table.Td className="device-lastseen-cell">
-                            {formatDate(device.lastseen, displayTimeZone)}
-                          </Table.Td>
-                          <Table.Td className="device-known-cell">
-                            <Badge
-                              className="device-known-badge"
-                              color={device.known ? 'teal' : 'yellow'}
-                              variant="light"
-                            >
-                              {device.known ? 'Known' : 'New'}
-                            </Badge>
-                          </Table.Td>
-                        </Table.Tr>
-                      ))}
-                    </Table.Tbody>
-                  </Table>
+                          </Box>
+                          <Box>
+                            <Text size="xs" c="dimmed">Last seen</Text>
+                            <Text>{formatDate(device.lastseen, displayTimeZone)}</Text>
+                          </Box>
+                        </div>
+                      </button>
+                    ))}
+                  </Stack>
                   <Stack className="device-mobile-list" gap={0}>
                     {filteredDevices.map((device) => (
                       <button
@@ -2538,7 +2901,7 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
                           </Box>
                           <Box className="device-mobile-wide">
                             <Text size="xs" c="dimmed">Role</Text>
-                            <Text size="sm">{device.role || 'device'}</Text>
+                            <Text size="sm">{formatRoleLabel(device.role)}</Text>
                           </Box>
                           <Box className="device-mobile-wide">
                             <Text size="xs" c="dimmed">MAC</Text>
@@ -2552,97 +2915,10 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
                       </button>
                     ))}
                   </Stack>
-                  <Divider />
-                  <Group className="devices-pagination" justify="space-between" p="md">
-                    <Text size="sm" c="dimmed">
-                      Showing {deviceStart}-{deviceEnd} of {devicePagination.count} devices
-                    </Text>
-                    <Pagination
-                      total={devicePageCount}
-                      value={devicePage}
-                      onChange={setDevicePage}
-                      size="sm"
-                      withEdges
-                    />
-                  </Group>
                 </>
               )}
             </Stack>
           </Paper>
-
-          <SimpleGrid cols={{ base: 1, md: 2 }}>
-            <Paper className="content-panel" radius="md" p="md">
-              <Stack>
-                <Group>
-                  <IconShieldCheck size={22} />
-                  <Title order={4}>Scan control</Title>
-                </Group>
-                <Text size="sm" c="dimmed">
-                  Last scan: {scanStatus ? formatDate(scanStatus.finished_at || scanStatus.started_at, displayTimeZone) : '-'}
-                </Text>
-                <Group gap="xs">
-                  <Badge color={scanVisibility?.is_scanning ? 'blue' : 'gray'} variant="light">
-                    {scanVisibility?.is_scanning ? 'Scanning' : 'Idle'}
-                  </Badge>
-                  <Text size="sm" c="dimmed">
-                    Range: {scanVisibility?.current_range || appSettings?.ip_range || '-'}
-                  </Text>
-                </Group>
-                <TextInput
-                  label="CIDR range"
-                  placeholder={
-                    appSettings?.ip_range
-                      ? `Use saved default (${appSettings.ip_range})`
-                      : 'Use saved default'
-                  }
-                  value={scanRange}
-                  onChange={(event) => setScanRange(event.currentTarget.value)}
-                />
-                <Button leftSection={<IconRefresh size={18} />} onClick={runScan} loading={refreshing}>
-                  Run scan
-                </Button>
-              </Stack>
-            </Paper>
-
-            <Paper className="content-panel" radius="md" p="md">
-              <Group mb="sm">
-                <IconClock size={22} />
-                <Title order={4}>Latest scan</Title>
-              </Group>
-              <SimpleGrid cols={2}>
-                <NumberReadout label="Seen" value={scanStatus?.devices_seen} />
-                <NumberReadout label="New" value={scanStatus?.new_devices} />
-                <NumberReadout label="Opened" value={scanStatus?.ports_opened} />
-                <NumberReadout label="Closed" value={scanStatus?.ports_closed} />
-              </SimpleGrid>
-              <Divider my="sm" />
-              <SimpleGrid cols={{ base: 1, sm: 2 }}>
-                <Box>
-                  <Text size="xs" c="dimmed">Started</Text>
-                  <Text fw={600}>{formatDate(scanVisibility?.started_at, displayTimeZone)}</Text>
-                </Box>
-                <Box>
-                  <Text size="xs" c="dimmed">Finished</Text>
-                  <Text fw={600}>{formatDate(scanVisibility?.finished_at, displayTimeZone)}</Text>
-                </Box>
-                <Box>
-                  <Text size="xs" c="dimmed">Duration</Text>
-                  <Text fw={600}>{formatDuration(scanVisibility?.duration_seconds)}</Text>
-                </Box>
-                <Box>
-                  <Text size="xs" c="dimmed">Status</Text>
-                  <Badge color={scanVisibility?.is_scanning ? 'blue' : scanStatus?.status === 'failed' ? 'red' : 'teal'} variant="light">
-                    {scanVisibility?.is_scanning ? 'running' : scanStatus?.status || '-'}
-                  </Badge>
-                </Box>
-              </SimpleGrid>
-              {scanVisibility?.last_error && (
-                <Alert mt="sm" color="red" icon={<IconAlertCircle size={18} />}>
-                  {scanVisibility.last_error}
-                </Alert>
-              )}
-            </Paper>
-          </SimpleGrid>
 
           <Tabs value={activeTab} onChange={(value) => setActiveTab(value || 'events')}>
             <Group justify="space-between" align="flex-end">
@@ -2830,18 +3106,6 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
   );
 }
 
-function NumberReadout({ label, value }) {
-  return (
-    <Box>
-      <Text size="xs" c="dimmed">
-        {label}
-      </Text>
-      <Text fw={700} size="xl">
-        {value ?? 0}
-      </Text>
-    </Box>
-  );
-}
 
 export default function Home() {
   const [user, setUser] = useState(null);

--- a/frontend/app/version.js
+++ b/frontend/app/version.js
@@ -4,6 +4,16 @@ export const APP_VERSION = packageInfo.version;
 
 export const CHANGELOG_ENTRIES = [
   {
+    version: '1.0.23',
+    date: '2026-08-10',
+    items: [
+      'Improved Docker dashboard layout with macOS-style status, health, scan, recent-change, and attention cards.',
+      'Improved Docker device browsing with card rows, room and role map views, and better macOS import compatibility.',
+      'Aligned macOS page headers with their sidebar icons and improved the LanGuard header icon in dark mode.',
+      'Improved Docker vendor lookup with bundled Wireshark manuf data and expanded hostname discovery fallbacks.',
+    ],
+  },
+  {
     version: '1.0.22',
     date: '2026-08-06',
     items: [

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "languard-frontend",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "languard-frontend",
-      "version": "1.0.22",
+      "version": "1.0.23",
       "dependencies": {
         "@mantine/core": "^9.5.0",
         "@mantine/hooks": "^9.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "languard-frontend",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/macos/LanGuardMac/Packaging/Info.plist
+++ b/macos/LanGuardMac/Packaging/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.22</string>
+	<string>1.0.23</string>
 	<key>CFBundleVersion</key>
-	<string>19</string>
+	<string>20</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/macos/LanGuardMac/README.md
+++ b/macos/LanGuardMac/README.md
@@ -35,7 +35,7 @@ The app bundle is created at `.build/app/LanGuard.app`.
 
 ```bash
 ./Scripts/build_dmg.sh
-open .build/release/LanGuard-1.0.22.dmg
+open .build/release/LanGuard-1.0.23.dmg
 ```
 
 Drag `LanGuard.app` into `Applications` from the DMG window.

--- a/macos/LanGuardMac/Sources/LanGuardMac/DashboardView.swift
+++ b/macos/LanGuardMac/Sources/LanGuardMac/DashboardView.swift
@@ -242,6 +242,7 @@ private struct HeroPanel: View {
         HeaderView(
             title: "LanGuard",
             subtitle: "Local network watch for macOS",
+            assetImage: "LanGuardIcon",
             version: AppVersion.current
         )
     }

--- a/macos/LanGuardMac/Sources/LanGuardMac/DevicesView.swift
+++ b/macos/LanGuardMac/Sources/LanGuardMac/DevicesView.swift
@@ -28,7 +28,8 @@ struct DevicesView: View {
         VStack(alignment: .leading, spacing: 20) {
             HeaderView(
                 title: "Devices",
-                subtitle: "Discovered network devices will appear here."
+                subtitle: "Discovered network devices will appear here.",
+                systemImage: "network"
             )
 
             if appModel.devices.isEmpty {
@@ -637,7 +638,8 @@ private struct DeviceDetailView: View {
         VStack(alignment: .leading, spacing: 20) {
             HeaderView(
                 title: originalDevice.name,
-                subtitle: originalDevice.ipAddress
+                subtitle: originalDevice.ipAddress,
+                systemImage: originalDevice.displayIconName
             )
 
             Form {

--- a/macos/LanGuardMac/Sources/LanGuardMac/GroupingView.swift
+++ b/macos/LanGuardMac/Sources/LanGuardMac/GroupingView.swift
@@ -28,7 +28,8 @@ struct GroupingView: View {
                 HStack(alignment: .top) {
                     HeaderView(
                         title: "Grouping",
-                        subtitle: "Browse devices by room or role."
+                        subtitle: "Browse devices by room or role.",
+                        systemImage: "point.3.connected.trianglepath.dotted"
                     )
                     Spacer()
                     Picker("Group by", selection: $mode) {

--- a/macos/LanGuardMac/Sources/LanGuardMac/GuestScanView.swift
+++ b/macos/LanGuardMac/Sources/LanGuardMac/GuestScanView.swift
@@ -13,7 +13,8 @@ struct GuestScanView: View {
             VStack(alignment: .leading, spacing: 24) {
                 HeaderView(
                     title: "Guest Scan",
-                    subtitle: "Scan a temporary network without saving devices."
+                    subtitle: "Scan a temporary network without saving devices.",
+                    systemImage: "person.crop.circle"
                 )
 
                 guestNotice

--- a/macos/LanGuardMac/Sources/LanGuardMac/HeaderView.swift
+++ b/macos/LanGuardMac/Sources/LanGuardMac/HeaderView.swift
@@ -1,20 +1,33 @@
+import AppKit
 import SwiftUI
 
 struct HeaderView: View {
+    @Environment(\.colorScheme) private var colorScheme
+
     let title: String
     let subtitle: String
+    var systemImage: String = "shield.lefthalf.filled.badge.checkmark"
+    var assetImage: String?
     var version: String?
 
     var body: some View {
         HStack(spacing: 14) {
             ZStack {
-                RoundedRectangle(cornerRadius: 14)
-                    .fill(.blue.opacity(0.16))
-                    .frame(width: 58, height: 58)
+                if let assetImage, let image = HeaderIconImage.load(named: assetImage) {
+                    Image(nsImage: image)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 58, height: 58)
+                        .shadow(color: assetIconShadowColor, radius: 6, y: 2)
+                } else {
+                    RoundedRectangle(cornerRadius: 14)
+                        .fill(.blue.opacity(0.16))
+                        .frame(width: 58, height: 58)
 
-                Image(systemName: "shield.lefthalf.filled.badge.checkmark")
-                    .font(.system(size: 34, weight: .semibold))
-                    .foregroundStyle(.blue)
+                    Image(systemName: systemImage)
+                        .font(.system(size: 34, weight: .semibold))
+                        .foregroundStyle(.blue)
+                }
             }
 
             VStack(alignment: .leading, spacing: 4) {
@@ -45,17 +58,53 @@ struct HeaderView: View {
             Spacer()
         }
     }
+
+    private var assetIconShadowColor: Color {
+        colorScheme == .dark ? .black.opacity(0.35) : .clear
+    }
+}
+
+private enum HeaderIconImage {
+    static func load(named name: String) -> NSImage? {
+        if let bundledImage = NSImage(named: name) {
+            return bundledImage
+        }
+
+        let resourceCandidates = [
+            Bundle.main.resourceURL,
+            Bundle.main.bundleURL.appending(path: "Contents/Resources", directoryHint: .isDirectory),
+            URL(fileURLWithPath: #filePath)
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .appending(path: "Resources", directoryHint: .isDirectory),
+        ].compactMap(\.self)
+
+        for resourceURL in resourceCandidates {
+            let imageURL = resourceURL.appending(path: "\(name).png")
+            if let image = NSImage(contentsOf: imageURL) {
+                return image
+            }
+        }
+
+        return nil
+    }
 }
 
 enum AppVersion {
     static var current: String {
         let bundleVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
         let normalizedVersion = bundleVersion?.trimmingCharacters(in: .whitespacesAndNewlines)
-        return normalizedVersion?.isEmpty == false ? normalizedVersion! : "1.0.22"
+        return normalizedVersion?.isEmpty == false ? normalizedVersion! : "1.0.23"
     }
 }
 
 #Preview {
-    HeaderView(title: "LanGuard", subtitle: "Local network watch for macOS", version: AppVersion.current)
+    HeaderView(
+        title: "LanGuard",
+        subtitle: "Local network watch for macOS",
+        assetImage: "LanGuardIcon",
+        version: AppVersion.current
+    )
         .padding()
 }

--- a/macos/LanGuardMac/Sources/LanGuardMac/ScanHistoryView.swift
+++ b/macos/LanGuardMac/Sources/LanGuardMac/ScanHistoryView.swift
@@ -9,7 +9,8 @@ struct ScanHistoryView: View {
             HStack(alignment: .center, spacing: 16) {
                 HeaderView(
                     title: "Scan History",
-                    subtitle: "Completed scans and changes will be tracked here."
+                    subtitle: "Completed scans and changes will be tracked here.",
+                    systemImage: "clock.arrow.circlepath"
                 )
 
                 if !appModel.scanHistory.isEmpty {

--- a/macos/LanGuardMac/Sources/LanGuardMac/Services/DeviceInventoryTransfer.swift
+++ b/macos/LanGuardMac/Sources/LanGuardMac/Services/DeviceInventoryTransfer.swift
@@ -60,7 +60,7 @@ struct DeviceInventoryItem: Codable {
         self.hostname = device.hostname
         self.icon = device.iconName
         self.secondaryIcon = device.secondaryIconName
-        self.role = device.role?.rawValue
+        self.role = device.effectiveRole.rawValue
         self.room = device.room
         self.known = device.isKnown
         self.isGateway = device.isGateway

--- a/macos/LanGuardMac/Sources/LanGuardMac/SettingsView.swift
+++ b/macos/LanGuardMac/Sources/LanGuardMac/SettingsView.swift
@@ -23,7 +23,8 @@ struct SettingsView: View {
         VStack(alignment: .leading, spacing: 20) {
             HeaderView(
                 title: "Settings",
-                subtitle: "Control how LanGuard scans this Mac's local network."
+                subtitle: "Control how LanGuard scans this Mac's local network.",
+                systemImage: "gearshape"
             )
 
             Form {

--- a/macos/LanGuardMac/Tests/LanGuardMacTests/LanGuardMacTests.swift
+++ b/macos/LanGuardMac/Tests/LanGuardMacTests/LanGuardMacTests.swift
@@ -75,6 +75,23 @@ func deviceNameGuesserFallsBackToMacSuffix() {
 }
 
 @Test
+func deviceInventoryExportUsesEffectiveRole() throws {
+    let device = NetworkDevice(
+        id: "aa:bb:cc:dd:ee:ff",
+        name: "Gateway",
+        ipAddress: "192.168.1.1",
+        macAddress: "aa:bb:cc:dd:ee:ff",
+        isGateway: true
+    )
+    let document = DeviceInventoryDocument(devices: [device])
+    let data = try JSONEncoder().encode(document)
+    let payload = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+    let devices = payload?["devices"] as? [[String: Any]]
+
+    #expect(devices?.first?["role"] as? String == "gateway")
+}
+
+@Test
 func vendorResolverFindsKnownOUI() {
     #expect(MACVendorResolver.vendor(for: "90:dd:5d:b7:bd:01") == "Apple, Inc.")
     #expect(MACVendorResolver.vendor(for: "90:ee:c7:f8:d4:e1") == "Samsung Electronics Co., Ltd.")


### PR DESCRIPTION
## Summary

- Bump LanGuard to v1.0.23 across Docker, backend, frontend, and macOS metadata.
- Improve Docker vendor detection with bundled Wireshark manuf data and stronger hostname discovery fallbacks.
- Improve Docker import compatibility for macOS exports, including icons, rooms, and roles.
- Redesign the Docker dashboard toward the macOS layout with status, health, scan, recent-change, and attention cards.
- Align macOS page headers with their sidebar icons and improve the LanGuard header icon in dark mode.

## Validation

- `python manage.py test` in `backend` passed: 116 tests.
- `npm run lint` in `frontend` passed.
- `swift test` in `macos/LanGuardMac` passed: 71 tests.
- `./Scripts/build_app.sh` in `macos/LanGuardMac` passed.
- `git diff --check` passed.