### PR TITLE
Release 1.1.2 hostname discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.1.2 - 2026-08-13
+
+- Improved Docker hostname discovery with LLMNR and cached SSDP/UPnP metadata lookup.
+- Prevented unrelated multicast PTR answers from assigning the wrong hostname to other devices.
+- Cleared stale read-only hostnames when the latest scan no longer resolves a valid hostname.
+- Aligned macOS hostname safety checks with Docker for mDNS and reverse PTR responses.
+
 ## 1.0.22 - 2026-08-06
 
 - Replaced bundled vendor lookup data with Wireshark manuf parsing and preserved original vendor names.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 <p align="center">
-  <img alt="Version" src="https://img.shields.io/badge/version-1.1.1-blue">
+  <img alt="Version" src="https://img.shields.io/badge/version-1.1.2-blue">
   <a href="https://github.com/users/hillaliy/packages/container/package/languard-backend">
     <img alt="Backend image" src="https://img.shields.io/badge/backend-GHCR-2ea44f">
   </a>

--- a/backend/core/scan.py
+++ b/backend/core/scan.py
@@ -2,11 +2,15 @@ import logging
 import ipaddress
 import os
 import random
+import re
 import socket
 import struct
+import time
+from urllib.parse import urlparse
 
 from django.conf import settings
 from django.utils import timezone
+import requests
 import scapy.all as scapy
 from scapy.data import ManufDA
 
@@ -17,6 +21,8 @@ from .notifications import notify_event
 LOGGER = logging.getLogger(__name__)
 DEFAULT_DEVICE_NAME = "Device"
 DEFAULT_DEVICE_ICONS = {"", "plus", "unknown", "device", "desktop"}
+SSDP_CACHE_TTL_SECONDS = 10
+SSDP_HOSTNAME_CACHE = {"expires_at": 0.0, "hostnames": {}}
 DEVICE_GUESS_RULES = [
     {
         "icon": "smart-hub",
@@ -286,9 +292,10 @@ def dns_read_name(packet, offset):
     return ".".join(label for label in labels if label), end_offset
 
 
-def dns_ptr_names(packet):
+def dns_ptr_names(packet, expected_owner=""):
     if len(packet) < 12:
         return []
+    normalized_expected_owner = (expected_owner or "").strip().lower().rstrip(".")
     try:
         qdcount, ancount, nscount, arcount = struct.unpack("!HHHH", packet[4:12])
     except struct.error:
@@ -299,7 +306,7 @@ def dns_ptr_names(packet):
         offset += 4
     names = []
     for _ in range(ancount + nscount + arcount):
-        _, offset = dns_read_name(packet, offset)
+        owner, offset = dns_read_name(packet, offset)
         if offset + 10 > len(packet):
             break
         record_type, _, _, rdlength = struct.unpack("!HHIH", packet[offset : offset + 10])
@@ -307,6 +314,9 @@ def dns_ptr_names(packet):
         rdata_offset = offset
         offset += rdlength
         if record_type == 12:
+            normalized_owner = owner.strip().lower().rstrip(".")
+            if normalized_expected_owner and normalized_owner != normalized_expected_owner:
+                continue
             name, _ = dns_read_name(packet, rdata_offset)
             if name:
                 names.append(name)
@@ -331,6 +341,20 @@ def udp_exchange(packet, address, port, timeout):
         return response
 
 
+def udp_responses(packet, address, port, timeout, max_responses=12):
+    responses = []
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+        sock.settimeout(timeout)
+        sock.sendto(packet, (address, port))
+        while len(responses) < max_responses:
+            try:
+                response, source = sock.recvfrom(4096)
+            except socket.timeout:
+                break
+            responses.append((response, source[0]))
+    return responses
+
+
 def mdns_reverse_hostname(ip):
     name = reverse_dns_name(ip)
     if not name:
@@ -343,7 +367,26 @@ def mdns_reverse_hostname(ip):
         except OSError as exc:
             LOGGER.debug("mDNS reverse lookup failed for %s via %s: %s", ip, address, exc)
     for response in responses:
-        for ptr_name in dns_ptr_names(response):
+        for ptr_name in dns_ptr_names(response, expected_owner=name):
+            cleaned = clean_hostname(ptr_name)
+            if cleaned:
+                return cleaned
+    return ""
+
+
+def llmnr_reverse_hostname(ip):
+    name = reverse_dns_name(ip)
+    if not name:
+        return ""
+    packet = dns_query_packet(name, query_type=12, query_id=0x4C47)
+    responses = []
+    for address in ("224.0.0.252", ip):
+        try:
+            responses.append(udp_exchange(packet, address, 5355, 0.6))
+        except OSError as exc:
+            LOGGER.debug("LLMNR reverse lookup failed for %s via %s: %s", ip, address, exc)
+    for response in responses:
+        for ptr_name in dns_ptr_names(response, expected_owner=name):
             cleaned = clean_hostname(ptr_name)
             if cleaned:
                 return cleaned
@@ -380,10 +423,86 @@ def netbios_hostname(ip):
     return ""
 
 
+def ssdp_hostname(ip):
+    return ssdp_hostname_map().get(ip, "")
+
+
+def ssdp_hostname_map():
+    now = time.monotonic()
+    if SSDP_HOSTNAME_CACHE["expires_at"] > now:
+        return dict(SSDP_HOSTNAME_CACHE["hostnames"])
+
+    packet = (
+        "M-SEARCH * HTTP/1.1\r\n"
+        "HOST: 239.255.255.250:1900\r\n"
+        'MAN: "ssdp:discover"\r\n'
+        "MX: 1\r\n"
+        "ST: ssdp:all\r\n"
+        "USER-AGENT: LanGuard/1.0 UPnP/1.1\r\n"
+        "\r\n"
+    ).encode("ascii")
+    try:
+        responses = udp_responses(packet, "239.255.255.250", 1900, 0.7)
+    except OSError as exc:
+        LOGGER.debug("SSDP lookup failed: %s", exc)
+        return {}
+
+    hostnames = {}
+    for response, source_ip in responses:
+        hostname = ssdp_hostname_from_response(response, source_ip)
+        if hostname:
+            hostnames[source_ip] = hostname
+
+    SSDP_HOSTNAME_CACHE["expires_at"] = now + SSDP_CACHE_TTL_SECONDS
+    SSDP_HOSTNAME_CACHE["hostnames"] = hostnames
+    return dict(hostnames)
+
+
+def ssdp_hostname_from_response(response, ip):
+    text = response.decode("utf-8", "ignore")
+    headers = parse_http_headers(text)
+    location = headers.get("location", "")
+    if not location:
+        return ""
+    parsed = urlparse(location)
+    if parsed.hostname and parsed.hostname != ip:
+        return ""
+    try:
+        result = requests.get(location, timeout=1.0, headers={"User-Agent": "LanGuard/1.0"})
+    except requests.RequestException as exc:
+        LOGGER.debug("SSDP device description fetch failed for %s: %s", ip, exc)
+        return ""
+    body = result.text[:128_000]
+    return hostname_from_device_description(body, ip)
+
+
+def parse_http_headers(text):
+    headers = {}
+    for line in text.splitlines()[1:]:
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        headers[key.strip().lower()] = value.strip()
+    return headers
+
+
+def hostname_from_device_description(body, ip=""):
+    for tag in ("friendlyName", "modelName"):
+        match = re.search(rf"<{tag}>\s*([^<]+)\s*</{tag}>", body or "", re.IGNORECASE)
+        if not match:
+            continue
+        hostname = clean_hostname(match.group(1))
+        if hostname and hostname != ip:
+            return hostname
+    return ""
+
+
 def get_hostname(ip):
     lookup_steps = (
         reverse_dns_hostname,
         mdns_reverse_hostname,
+        llmnr_reverse_hostname,
+        ssdp_hostname,
         netbios_hostname,
     )
     for lookup in lookup_steps:
@@ -958,8 +1077,9 @@ def sync_discovered_device(element, oui=None, scan_run=None, scan_started_at=Non
         device.online = True
         device.lastseen = scan_started_at
         device.missed_scans = 0
-        if hostname and device.hostname != hostname[:255]:
-            device.hostname = hostname[:255]
+        resolved_hostname = hostname[:255] if hostname else ""
+        if device.hostname != resolved_hostname:
+            device.hostname = resolved_hostname
             update_fields.append("hostname")
         resolved_vendor = preferred_vendor(
             observed_vendor=vendor_name,

--- a/backend/core/tests.py
+++ b/backend/core/tests.py
@@ -29,13 +29,18 @@ from .scan import (
     clean_hostname,
     default_gateway_from_proc_route,
     discover_devices,
+    dns_encode_name,
+    dns_ptr_names,
     guess_device_identity,
     get_hostname,
+    hostname_from_device_description,
+    llmnr_reverse_hostname,
     ManufVendorDB,
     mark_missing_devices_offline,
     manuf_vendor,
     normalize_scan_ports,
     preferred_vendor,
+    ssdp_hostname_from_response,
     sync_discovered_device,
     sync_device_ports,
     validate_ip_range,
@@ -82,16 +87,104 @@ class HostnameResolutionTests(SimpleTestCase):
         self.assertEqual(clean_hostname(""), "")
 
     @patch("core.scan.netbios_hostname", return_value="")
+    @patch("core.scan.ssdp_hostname", return_value="")
+    @patch("core.scan.llmnr_reverse_hostname", return_value="")
     @patch("core.scan.mdns_reverse_hostname", return_value="")
     @patch("core.scan.socket.gethostbyaddr", side_effect=socket.herror)
     def test_get_hostname_returns_blank_when_reverse_dns_is_unavailable(self, *_):
         self.assertEqual(get_hostname("192.168.1.10"), "")
 
     @patch("core.scan.netbios_hostname", return_value="")
+    @patch("core.scan.ssdp_hostname", return_value="")
+    @patch("core.scan.llmnr_reverse_hostname", return_value="")
     @patch("core.scan.mdns_reverse_hostname", return_value="haa switch")
     @patch("core.scan.socket.gethostbyaddr", side_effect=socket.herror)
     def test_get_hostname_uses_mdns_fallback(self, *_):
         self.assertEqual(get_hostname("192.168.1.21"), "haa switch")
+
+    @patch("core.scan.netbios_hostname", return_value="")
+    @patch("core.scan.ssdp_hostname", return_value="")
+    @patch("core.scan.llmnr_reverse_hostname", return_value="office pc")
+    @patch("core.scan.mdns_reverse_hostname", return_value="")
+    @patch("core.scan.socket.gethostbyaddr", side_effect=socket.herror)
+    def test_get_hostname_uses_llmnr_fallback(self, *_):
+        self.assertEqual(get_hostname("192.168.1.22"), "office pc")
+
+    @patch("core.scan.netbios_hostname", return_value="")
+    @patch("core.scan.ssdp_hostname", return_value="Archer BE550")
+    @patch("core.scan.llmnr_reverse_hostname", return_value="")
+    @patch("core.scan.mdns_reverse_hostname", return_value="")
+    @patch("core.scan.socket.gethostbyaddr", side_effect=socket.herror)
+    def test_get_hostname_uses_ssdp_fallback(self, *_):
+        self.assertEqual(get_hostname("192.168.1.1"), "Archer BE550")
+
+    def test_dns_ptr_names_returns_matching_owner(self):
+        packet = (
+            b"\x00\x00\x84\x00\x00\x00\x00\x01\x00\x00\x00\x00"
+            + dns_encode_name("21.1.168.192.in-addr.arpa")
+            + b"\x00\x0c\x00\x01\x00\x00\x00\x78"
+            + len(dns_encode_name("HAA-123456.local")).to_bytes(2, "big")
+            + dns_encode_name("HAA-123456.local")
+        )
+
+        self.assertEqual(
+            dns_ptr_names(packet, expected_owner="21.1.168.192.in-addr.arpa"),
+            ["HAA-123456.local"],
+        )
+
+    def test_dns_ptr_names_ignores_unrelated_mdns_answer(self):
+        packet = (
+            b"\x00\x00\x84\x00\x00\x00\x00\x01\x00\x00\x00\x00"
+            + dns_encode_name("22.1.168.192.in-addr.arpa")
+            + b"\x00\x0c\x00\x01\x00\x00\x00\x78"
+            + len(dns_encode_name("Aqara-Hub.local")).to_bytes(2, "big")
+            + dns_encode_name("Aqara-Hub.local")
+        )
+
+        self.assertEqual(
+            dns_ptr_names(packet, expected_owner="21.1.168.192.in-addr.arpa"),
+            [],
+        )
+
+    @patch("core.scan.udp_exchange")
+    def test_llmnr_reverse_hostname_uses_matching_ptr(self, udp_exchange):
+        packet = (
+            b"\x4c\x47\x84\x00\x00\x00\x00\x01\x00\x00\x00\x00"
+            + dns_encode_name("22.1.168.192.in-addr.arpa")
+            + b"\x00\x0c\x00\x01\x00\x00\x00\x78"
+            + len(dns_encode_name("Office-PC.local")).to_bytes(2, "big")
+            + dns_encode_name("Office-PC.local")
+        )
+        udp_exchange.side_effect = [packet, OSError("timeout")]
+
+        self.assertEqual(llmnr_reverse_hostname("192.168.1.22"), "Office PC")
+
+    def test_hostname_from_device_description_prefers_friendly_name(self):
+        body = "<root><friendlyName>Archer BE550</friendlyName><modelName>Router</modelName></root>"
+
+        self.assertEqual(hostname_from_device_description(body, "192.168.1.1"), "Archer BE550")
+
+    @patch("core.scan.requests.get")
+    def test_ssdp_hostname_from_response_fetches_device_description(self, get):
+        get.return_value.text = "<root><friendlyName>Archer BE550</friendlyName></root>"
+        response = (
+            b"HTTP/1.1 200 OK\r\n"
+            b"LOCATION: http://192.168.1.1:80/rootDesc.xml\r\n"
+            b"\r\n"
+        )
+
+        self.assertEqual(ssdp_hostname_from_response(response, "192.168.1.1"), "Archer BE550")
+
+    @patch("core.scan.requests.get")
+    def test_ssdp_hostname_from_response_ignores_other_device_location(self, get):
+        response = (
+            b"HTTP/1.1 200 OK\r\n"
+            b"LOCATION: http://192.168.1.99:80/rootDesc.xml\r\n"
+            b"\r\n"
+        )
+
+        self.assertEqual(ssdp_hostname_from_response(response, "192.168.1.1"), "")
+        get.assert_not_called()
 
     def test_manuf_parser_preserves_original_vendor_name(self):
         entry = ManufVendorDB.parse_line(
@@ -602,6 +695,27 @@ class ScanStabilityTests(TestCase):
 
         device.refresh_from_db()
         self.assertEqual(device.vendor, "")
+        self.assertEqual(device.name, "Bedroom AC")
+
+    @override_settings(PORT_SCAN_ENABLED=False)
+    @patch("core.scan.get_hostname", return_value="")
+    def test_existing_device_hostname_is_cleared_when_current_scan_has_no_hostname(self, _):
+        device = Device.objects.create(
+            name="Bedroom AC",
+            ip="192.168.1.70",
+            mac="aa:bb:cc:dd:ee:ff",
+            hostname="Aqara Hub",
+            known=True,
+        )
+
+        sync_discovered_device(
+            self.scan_element(device.ip, device.mac),
+            oui=None,
+            scan_run=ScanRun.objects.create(ip_range="192.168.1.0/24"),
+        )
+
+        device.refresh_from_db()
+        self.assertEqual(device.hostname, "")
         self.assertEqual(device.name, "Bedroom AC")
 
     @patch("builtins.open")

--- a/frontend/app/version.js
+++ b/frontend/app/version.js
@@ -4,6 +4,16 @@ export const APP_VERSION = packageInfo.version;
 
 export const CHANGELOG_ENTRIES = [
   {
+    version: '1.1.2',
+    date: '2026-08-13',
+    items: [
+      'Improved Docker hostname discovery with LLMNR and cached SSDP/UPnP metadata lookup.',
+      'Prevented unrelated multicast PTR answers from assigning the wrong hostname to other devices.',
+      'Cleared stale read-only hostnames when the latest scan no longer resolves a valid hostname.',
+      'Aligned macOS hostname safety checks with Docker for mDNS and reverse PTR responses.',
+    ],
+  },
+  {
     version: '1.1.1',
     date: '2026-08-11',
     items: [

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "languard-frontend",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "languard-frontend",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "dependencies": {
         "@mantine/core": "^9.5.1",
         "@mantine/hooks": "^9.5.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "languard-frontend",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/macos/LanGuardMac/Packaging/Info.plist
+++ b/macos/LanGuardMac/Packaging/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.1</string>
+	<string>1.1.2</string>
 	<key>CFBundleVersion</key>
-	<string>22</string>
+	<string>23</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/macos/LanGuardMac/README.md
+++ b/macos/LanGuardMac/README.md
@@ -35,7 +35,7 @@ The app bundle is created at `.build/app/LanGuard.app`.
 
 ```bash
 ./Scripts/build_dmg.sh
-open .build/release/LanGuard-1.1.1.dmg
+open .build/release/LanGuard-1.1.2.dmg
 ```
 
 Drag `LanGuard.app` into `Applications` from the DMG window.

--- a/macos/LanGuardMac/Sources/LanGuardMac/HeaderView.swift
+++ b/macos/LanGuardMac/Sources/LanGuardMac/HeaderView.swift
@@ -95,7 +95,7 @@ enum AppVersion {
     static var current: String {
         let bundleVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
         let normalizedVersion = bundleVersion?.trimmingCharacters(in: .whitespacesAndNewlines)
-        return normalizedVersion?.isEmpty == false ? normalizedVersion! : "1.1.1"
+        return normalizedVersion?.isEmpty == false ? normalizedVersion! : "1.1.2"
     }
 }
 

--- a/macos/LanGuardMac/Sources/LanGuardMac/Services/DeviceMerger.swift
+++ b/macos/LanGuardMac/Sources/LanGuardMac/Services/DeviceMerger.swift
@@ -42,7 +42,7 @@ enum DeviceMerger {
                 merged.iconName = device.iconName
                 merged.secondaryIconName = device.secondaryIconName
             }
-            merged.hostname = preferredHostname(device.hostname, fallback: previous.hostname)
+            merged.hostname = HostnameResolver.clean(device.hostname)
             merged.vendor = MACVendorResolver.displayVendor(device.vendor)
             merged.role = previous.role
             merged.room = previous.room

--- a/macos/LanGuardMac/Sources/LanGuardMac/Services/NetworkMetadataDiscovery.swift
+++ b/macos/LanGuardMac/Sources/LanGuardMac/Services/NetworkMetadataDiscovery.swift
@@ -415,12 +415,19 @@ struct MDNSReverseMetadataDiscovery: NetworkMetadataDiscovering {
     }
 
     static func hostname(from output: String, ipAddress: String) -> String? {
+        let expectedOwner = reversePTRQuery(for: ipAddress)
         for line in output.components(separatedBy: .newlines) {
             let fields = line.split(whereSeparator: \.isWhitespace).map(String.init)
             guard
                 let ptrIndex = fields.firstIndex(where: { $0.caseInsensitiveCompare("PTR") == .orderedSame }),
                 fields.indices.contains(ptrIndex + 1)
             else {
+                continue
+            }
+
+            if let expectedOwner,
+               let owner = fields.prefix(ptrIndex).last,
+               normalizedDNSName(owner) != normalizedDNSName(expectedOwner) {
                 continue
             }
 
@@ -441,6 +448,18 @@ struct MDNSReverseMetadataDiscovery: NetworkMetadataDiscovering {
             }
         }
         return nil
+    }
+
+    private static func reversePTRQuery(for ipAddress: String) -> String? {
+        let parts = ipAddress.split(separator: ".")
+        guard parts.count == 4, parts.allSatisfy({ UInt8($0) != nil }) else {
+            return nil
+        }
+        return parts.reversed().joined(separator: ".") + ".in-addr.arpa"
+    }
+
+    private static func normalizedDNSName(_ value: String) -> String {
+        value.trimmingCharacters(in: CharacterSet(charactersIn: ".")).lowercased()
     }
 
     private func resolveHostname(ipAddress: String, timeout: TimeInterval) async -> String? {
@@ -1084,9 +1103,13 @@ enum DNSPTRPacketParser {
             offset += 4
         }
 
+        let expectedOwner = reversePTRName(for: ipAddress)
         for _ in 0..<answerCount {
-            guard skipName(bytes, offset: &offset),
-                  let recordType = readUInt16(bytes, at: offset),
+            guard let recordName = readName(bytes, offset: offset) else {
+                return nil
+            }
+            offset = recordName.nextOffset
+            guard let recordType = readUInt16(bytes, at: offset),
                   offset + 10 <= bytes.count else {
                 return nil
             }
@@ -1103,6 +1126,7 @@ enum DNSPTRPacketParser {
             guard dataEnd <= bytes.count else { return nil }
 
             if recordType == 0x000c,
+               normalizedDNSName(recordName.name) == expectedOwner,
                let candidate = readName(bytes, offset: dataOffset)?.name,
                let hostname = HostnameResolver.clean(candidate, ipAddress: ipAddress) {
                 return hostname
@@ -1112,6 +1136,18 @@ enum DNSPTRPacketParser {
         }
 
         return nil
+    }
+
+    private static func reversePTRName(for ipAddress: String) -> String? {
+        let parts = ipAddress.split(separator: ".")
+        guard parts.count == 4, parts.allSatisfy({ UInt8($0) != nil }) else {
+            return nil
+        }
+        return parts.reversed().joined(separator: ".") + ".in-addr.arpa"
+    }
+
+    private static func normalizedDNSName(_ value: String) -> String {
+        value.trimmingCharacters(in: CharacterSet(charactersIn: ".")).lowercased()
     }
 
     static func hostnamesByIPv4Address(from response: Data) -> [String: String] {

--- a/macos/LanGuardMac/Tests/LanGuardMacTests/DeviceMergerTests.swift
+++ b/macos/LanGuardMac/Tests/LanGuardMacTests/DeviceMergerTests.swift
@@ -334,6 +334,29 @@ func deviceMergerClearsInvalidStoredHostname() {
 }
 
 @Test
+func deviceMergerClearsStaleHostnameWhenLatestScanHasNoHostname() {
+    let existing = NetworkDevice(
+        id: "00:11:22:33:44:55",
+        name: "Bedroom AC",
+        ipAddress: "192.168.0.70",
+        macAddress: "00:11:22:33:44:55",
+        hostname: "Aqara Hub",
+        isKnown: true
+    )
+    let discovered = NetworkDevice(
+        id: "00:11:22:33:44:55",
+        name: "Unknown Device 4455",
+        ipAddress: "192.168.0.70",
+        macAddress: "00:11:22:33:44:55"
+    )
+
+    let result = DeviceMerger.merge(existing: [existing], discovered: [discovered])
+
+    #expect(result.devices.first?.name == "Bedroom AC")
+    #expect(result.devices.first?.hostname == nil)
+}
+
+@Test
 func deviceMergerClearsStaleVendorForLocallyAdministeredMacAddress() {
     let existing = NetworkDevice(
         id: "ba:e6:e0:17:66:94",

--- a/macos/LanGuardMac/Tests/LanGuardMacTests/LanGuardMacTests.swift
+++ b/macos/LanGuardMac/Tests/LanGuardMacTests/LanGuardMacTests.swift
@@ -219,6 +219,16 @@ func mdnsReverseMetadataParsesDNSServiceOutput() {
 }
 
 @Test
+func mdnsReverseMetadataIgnoresUnrelatedDNSServiceOutput() {
+    let output = """
+    DATE: ---Wed 05 Aug 2026---
+    22:15:01.000  Add     2   4 21.0.168.192.in-addr.arpa. PTR IN 0 Aqara-Hub.local.
+    """
+
+    #expect(MDNSReverseMetadataDiscovery.hostname(from: output, ipAddress: "192.168.0.79") == nil)
+}
+
+@Test
 func multicastPTRMetadataParsesCompressedDNSResponse() {
     var response = Data()
 
@@ -266,6 +276,56 @@ func multicastPTRMetadataParsesCompressedDNSResponse() {
 
     #expect(LLMNRReverseMetadataDiscovery.hostname(from: response, ipAddress: "192.168.0.79") == "Apple Watch")
     #expect(MDNSPTRSocketDiscovery.hostname(from: response, ipAddress: "192.168.0.79") == "Apple Watch")
+}
+
+@Test
+func multicastPTRMetadataIgnoresUnrelatedCompressedDNSResponse() {
+    var response = Data()
+
+    func appendUInt16(_ value: UInt16) {
+        response.append(UInt8((value >> 8) & 0xff))
+        response.append(UInt8(value & 0xff))
+    }
+
+    func appendUInt32(_ value: UInt32) {
+        response.append(UInt8((value >> 24) & 0xff))
+        response.append(UInt8((value >> 16) & 0xff))
+        response.append(UInt8((value >> 8) & 0xff))
+        response.append(UInt8(value & 0xff))
+    }
+
+    func appendName(_ name: String) {
+        for label in name.split(separator: ".") {
+            let bytes = Array(label.utf8)
+            response.append(UInt8(bytes.count))
+            response.append(contentsOf: bytes)
+        }
+        response.append(0x00)
+    }
+
+    appendUInt16(0x4c47)
+    appendUInt16(0x8000)
+    appendUInt16(0x0001)
+    appendUInt16(0x0001)
+    appendUInt16(0x0000)
+    appendUInt16(0x0000)
+    appendName("79.0.168.192.in-addr.arpa")
+    appendUInt16(0x000c)
+    appendUInt16(0x0001)
+    appendName("21.0.168.192.in-addr.arpa")
+    appendUInt16(0x000c)
+    appendUInt16(0x0001)
+    appendUInt32(120)
+
+    let hostnameStart = response.count
+    appendUInt16(0)
+    appendName("Aqara-Hub.local")
+    let hostnameLength = response.count - hostnameStart - 2
+    response[hostnameStart] = UInt8((hostnameLength >> 8) & 0xff)
+    response[hostnameStart + 1] = UInt8(hostnameLength & 0xff)
+
+    #expect(LLMNRReverseMetadataDiscovery.hostname(from: response, ipAddress: "192.168.0.79") == nil)
+    #expect(MDNSPTRSocketDiscovery.hostname(from: response, ipAddress: "192.168.0.79") == nil)
 }
 
 @Test


### PR DESCRIPTION
## Summary

- Bump LanGuard to v1.1.2 across Docker/frontend and macOS metadata.
- Improve Docker hostname discovery with LLMNR and cached SSDP/UPnP metadata lookup.
- Reject unrelated multicast PTR answers so one device hostname cannot be assigned to other devices.
- Clear stale read-only hostnames when the latest scan no longer resolves a valid hostname.
- Align macOS mDNS/reverse PTR hostname safety checks with Docker.

## Validation

- `/Users/yossihillali/LanGuard/.venv/bin/python manage.py test` in `backend`
- `swift test` in `macos/LanGuardMac`
- `git diff --check`