### PR TITLE
Prevent device list IP wrapping

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -553,6 +553,13 @@ textarea {
   white-space: nowrap;
 }
 
+.device-list-ip-value {
+  display: block;
+  min-width: 108px;
+  overflow-wrap: normal;
+  white-space: nowrap;
+}
+
 .device-list-last-seen {
   min-width: 170px;
 }

--- a/frontend/app/page.jsx
+++ b/frontend/app/page.jsx
@@ -2968,7 +2968,7 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
                           </Box>
                           <Box>
                             <Text size="xs" c="dimmed">IP</Text>
-                            <Text fw={700} className="mobile-mono-value">{device.ip}</Text>
+                            <Text fw={700} className="mobile-mono-value device-list-ip-value">{device.ip}</Text>
                           </Box>
                           <Box>
                             <Text size="xs" c="dimmed">Room</Text>


### PR DESCRIPTION
## Summary
- Prevent IP values from wrapping in the Docker device list.
- Keep the existing wrapping behavior for other mobile mono fields.

## Validation
- npm run lint
- npm run build
- git diff --check