### PR TITLE
Release 1.3.1 macOS and Docker fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Reduced SQLite database lock errors in Docker by enabling a longer busy timeout and WAL mode.
 - Prevented scheduled activity cleanup from running at the same time as the startup scan.
+- Improved Docker dashboard/page responsiveness by avoiding full activity-history loads during startup and page navigation.
+- Added database indexes for scan history, events, and notification history.
 
 ## 1.3.0 - 2026-08-23
 

--- a/backend/core/migrations/0016_activity_performance_indexes.py
+++ b/backend/core/migrations/0016_activity_performance_indexes.py
@@ -1,0 +1,67 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0015_notificationdelivery_event_set_null"),
+    ]
+
+    operations = [
+        migrations.AddIndex(
+            model_name="scanrun",
+            index=models.Index(
+                fields=["-started_at"],
+                name="core_scanrun_started_desc_idx",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="scanrun",
+            index=models.Index(
+                fields=["status", "-started_at"],
+                name="core_scanrun_status_idx",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="networkevent",
+            index=models.Index(
+                fields=["-created_at"],
+                name="core_event_created_desc_idx",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="networkevent",
+            index=models.Index(
+                fields=["event_type", "-created_at"],
+                name="core_event_type_created_idx",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="networkevent",
+            index=models.Index(
+                fields=["notified", "-created_at"],
+                name="core_event_notified_idx",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="notificationdelivery",
+            index=models.Index(
+                fields=["-created_at"],
+                name="core_notify_created_desc_idx",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="notificationdelivery",
+            index=models.Index(
+                fields=["channel", "-created_at"],
+                name="core_notify_channel_idx",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="notificationdelivery",
+            index=models.Index(
+                fields=["status", "-created_at"],
+                name="core_notify_status_created_idx",
+            ),
+        ),
+    ]

--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -99,6 +99,10 @@ class ScanRun(models.Model):
 
     class Meta:
         ordering = ["-started_at"]
+        indexes = [
+            models.Index(fields=["-started_at"], name="core_scanrun_started_desc_idx"),
+            models.Index(fields=["status", "-started_at"], name="core_scanrun_status_idx"),
+        ]
 
     def __str__(self):
         return f"Scan {self.ip_range} - {self.status}"
@@ -139,6 +143,11 @@ class NetworkEvent(models.Model):
 
     class Meta:
         ordering = ["-created_at"]
+        indexes = [
+            models.Index(fields=["-created_at"], name="core_event_created_desc_idx"),
+            models.Index(fields=["event_type", "-created_at"], name="core_event_type_created_idx"),
+            models.Index(fields=["notified", "-created_at"], name="core_event_notified_idx"),
+        ]
 
     def __str__(self):
         return self.message
@@ -175,6 +184,11 @@ class NotificationDelivery(models.Model):
 
     class Meta:
         ordering = ["-created_at"]
+        indexes = [
+            models.Index(fields=["-created_at"], name="core_notify_created_desc_idx"),
+            models.Index(fields=["channel", "-created_at"], name="core_notify_channel_idx"),
+            models.Index(fields=["status", "-created_at"], name="core_notify_status_created_idx"),
+        ]
 
     def __str__(self):
         return f"{self.channel} {self.status} - {self.event_id}"

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -1093,7 +1093,7 @@ def scan_runs(request):
         runs,
         ScanRunSerializer,
         default_limit=25,
-        max_limit=100,
+        max_limit=500,
     )
 
 
@@ -1172,7 +1172,7 @@ def events(request):
         queryset,
         NetworkEventSerializer,
         default_limit=50,
-        max_limit=200,
+        max_limit=500,
     )
 
 
@@ -1209,7 +1209,7 @@ def notifications(request):
         queryset,
         NotificationDeliverySerializer,
         default_limit=50,
-        max_limit=200,
+        max_limit=500,
     )
 
 

--- a/frontend/app/page.jsx
+++ b/frontend/app/page.jsx
@@ -3197,7 +3197,7 @@ function ActivityTablePanel({ children }) {
   );
 }
 
-function EventsPage({ events, eventType, setEventType, timeZone }) {
+function EventsPage({ events, eventType, setEventType, timeZone, pagination }) {
   return (
     <Stack gap="lg">
       <Group justify="space-between" align="flex-end">
@@ -3211,7 +3211,7 @@ function EventsPage({ events, eventType, setEventType, timeZone }) {
           </Box>
         </Group>
         <Group gap="sm">
-          <Badge variant="light">{events.length} records</Badge>
+          <Badge variant="light">{activityRecordLabel(pagination, events.length)}</Badge>
           <Select
             w={220}
             placeholder="Event type"
@@ -3257,7 +3257,7 @@ function EventsPage({ events, eventType, setEventType, timeZone }) {
   );
 }
 
-function ScanHistoryPage({ scanRuns, timeZone }) {
+function ScanHistoryPage({ scanRuns, timeZone, pagination }) {
   return (
     <Stack gap="lg">
       <Group justify="space-between" align="flex-end">
@@ -3270,7 +3270,7 @@ function ScanHistoryPage({ scanRuns, timeZone }) {
             <Text c="dimmed">Recent scan runs and detected changes</Text>
           </Box>
         </Group>
-        <Badge variant="light">{scanRuns.length} records</Badge>
+        <Badge variant="light">{activityRecordLabel(pagination, scanRuns.length)}</Badge>
       </Group>
 
       <ActivityTablePanel>
@@ -3305,7 +3305,7 @@ function ScanHistoryPage({ scanRuns, timeZone }) {
   );
 }
 
-function NotificationsPage({ notifications: deliveries, timeZone }) {
+function NotificationsPage({ notifications: deliveries, timeZone, pagination }) {
   return (
     <Stack gap="lg">
       <Group justify="space-between" align="flex-end">
@@ -3318,7 +3318,7 @@ function NotificationsPage({ notifications: deliveries, timeZone }) {
             <Text c="dimmed">Delivery status for external notification channels</Text>
           </Box>
         </Group>
-        <Badge variant="light">{deliveries.length} records</Badge>
+        <Badge variant="light">{activityRecordLabel(pagination, deliveries.length)}</Badge>
       </Group>
 
       <ActivityTablePanel>
@@ -3351,27 +3351,14 @@ function NotificationsPage({ notifications: deliveries, timeZone }) {
   );
 }
 
-async function fetchAllPaginated(path, params = {}) {
-  const limit = 100;
-  let offset = 0;
-  const allItems = [];
+const activityPageLimit = 500;
 
-  while (true) {
-    const payload = await apiRequest(path, {
-      params: {
-        ...params,
-        limit,
-        offset,
-      },
-    });
-    allItems.push(...(payload.data || []));
-
-    const nextOffset = payload.pagination?.next_offset;
-    if (nextOffset === null || nextOffset === undefined) {
-      return allItems;
-    }
-    offset = nextOffset;
+function activityRecordLabel(pagination, loadedCount) {
+  const total = pagination?.count ?? loadedCount;
+  if (total > loadedCount) {
+    return `Latest ${loadedCount} of ${total} records`;
   }
+  return `${loadedCount} records`;
 }
 
 function Dashboard({ user, onLogout, onUserUpdated }) {
@@ -3392,8 +3379,12 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
   const [scanStatus, setScanStatus] = useState(null);
   const [scanVisibility, setScanVisibility] = useState(null);
   const [scanRuns, setScanRuns] = useState([]);
+  const [scanRunPagination, setScanRunPagination] = useState(null);
+  const [dashboardEvents, setDashboardEvents] = useState([]);
   const [events, setEvents] = useState([]);
+  const [eventPagination, setEventPagination] = useState(null);
   const [notifications, setNotifications] = useState([]);
+  const [notificationPagination, setNotificationPagination] = useState(null);
   const [appSettings, setAppSettings] = useState(null);
   const [dashboardTimeZone, setDashboardTimeZone] = useState();
   const [search, setSearch] = useState('');
@@ -3416,7 +3407,6 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
   const tableStateRef = useRef({
     search: '',
     deviceStatus: '',
-    eventType: '',
     deviceLimit: 100,
     deviceOffset: 0,
     deviceOrdering: '',
@@ -3442,12 +3432,11 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
     tableStateRef.current = {
       search,
       deviceStatus,
-      eventType,
       deviceLimit,
       deviceOffset,
       deviceOrdering,
     };
-  }, [search, deviceStatus, eventType, deviceOrdering]);
+  }, [search, deviceStatus, deviceOrdering]);
 
   async function loadData({ quiet = false, notifyOnError = false, notifyOnSuccess = false } = {}) {
     if (quiet) {
@@ -3470,25 +3459,23 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
         offset: currentTableState.deviceOffset,
         ordering: currentTableState.deviceOrdering || undefined,
       };
-      const eventParams = {
-        event_type: currentTableState.eventType || undefined,
-      };
       const mapDeviceParams = {
         limit: 100,
         ordering: 'ip',
+      };
+      const dashboardEventParams = {
+        limit: 8,
       };
 
       const settingsRequest = canManageUsers
         ? apiRequest('settings/')
         : Promise.resolve({ data: null });
-      const [deviceData, mapDeviceData, statusData, runData, eventData, notificationData, settingsData] =
+      const [deviceData, mapDeviceData, statusData, dashboardEventData, settingsData] =
         await Promise.all([
           apiRequest('device/', { params: deviceParams }),
           apiRequest('device/', { params: mapDeviceParams }),
           apiRequest('scan/status/'),
-          fetchAllPaginated('scan/runs/'),
-          fetchAllPaginated('events/', eventParams),
-          fetchAllPaginated('notifications/'),
+          apiRequest('events/', { params: dashboardEventParams }),
           settingsRequest,
         ]);
 
@@ -3509,9 +3496,7 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
       if (statusData.time_zone) {
         setDashboardTimeZone(statusData.time_zone);
       }
-      setScanRuns(runData || []);
-      setEvents(eventData || []);
-      setNotifications(notificationData || []);
+      setDashboardEvents(dashboardEventData.data || []);
       if (settingsData.data) {
         setAppSettings(settingsData.data);
       }
@@ -3549,6 +3534,58 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
     } catch (err) {
       if (notifyOnError) {
         showErrorNotification('Scan refresh failed', err.message);
+      }
+    }
+  }
+
+  async function loadEventsData({ notifyOnError = false } = {}) {
+    try {
+      const payload = await apiRequest('events/', {
+        params: {
+          event_type: eventType || undefined,
+          limit: activityPageLimit,
+          offset: 0,
+        },
+      });
+      setEvents(payload.data || []);
+      setEventPagination(payload.pagination || null);
+    } catch (err) {
+      if (notifyOnError) {
+        showErrorNotification('Events refresh failed', err.message);
+      }
+    }
+  }
+
+  async function loadScanRunsData({ notifyOnError = false } = {}) {
+    try {
+      const payload = await apiRequest('scan/runs/', {
+        params: {
+          limit: activityPageLimit,
+          offset: 0,
+        },
+      });
+      setScanRuns(payload.data || []);
+      setScanRunPagination(payload.pagination || null);
+    } catch (err) {
+      if (notifyOnError) {
+        showErrorNotification('Scan history refresh failed', err.message);
+      }
+    }
+  }
+
+  async function loadNotificationsData({ notifyOnError = false } = {}) {
+    try {
+      const payload = await apiRequest('notifications/', {
+        params: {
+          limit: activityPageLimit,
+          offset: 0,
+        },
+      });
+      setNotifications(payload.data || []);
+      setNotificationPagination(payload.pagination || null);
+    } catch (err) {
+      if (notifyOnError) {
+        showErrorNotification('Notifications refresh failed', err.message);
       }
     }
   }
@@ -3599,9 +3636,27 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
   }, []);
 
   useEffect(() => {
+    if (mainView === 'events') {
+      loadEventsData({ notifyOnError: true });
+    }
+  }, [mainView, eventType]);
+
+  useEffect(() => {
+    if (mainView === 'history') {
+      loadScanRunsData({ notifyOnError: true });
+    }
+  }, [mainView]);
+
+  useEffect(() => {
+    if (mainView === 'notifications') {
+      loadNotificationsData({ notifyOnError: true });
+    }
+  }, [mainView]);
+
+  useEffect(() => {
     const timer = window.setTimeout(() => loadData({ quiet: true }), 250);
     return () => window.clearTimeout(timer);
-  }, [search, deviceStatus, eventType, deviceOrdering]);
+  }, [search, deviceStatus, deviceOrdering]);
 
   async function runScan() {
     setRefreshing(true);
@@ -3849,11 +3904,20 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
               eventType={eventType}
               setEventType={setEventType}
               timeZone={displayTimeZone}
+              pagination={eventPagination}
             />
           ) : mainView === 'history' ? (
-            <ScanHistoryPage scanRuns={scanRuns} timeZone={displayTimeZone} />
+            <ScanHistoryPage
+              scanRuns={scanRuns}
+              timeZone={displayTimeZone}
+              pagination={scanRunPagination}
+            />
           ) : mainView === 'notifications' ? (
-            <NotificationsPage notifications={notifications} timeZone={displayTimeZone} />
+            <NotificationsPage
+              notifications={notifications}
+              timeZone={displayTimeZone}
+              pagination={notificationPagination}
+            />
           ) : (
             <>
           <DashboardStatusCards counters={counters} />
@@ -3870,7 +3934,7 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
           </div>
 
           <DashboardInsightCards
-            events={events}
+            events={dashboardEvents}
             devices={mapDevices}
             onSelectDevice={(device) => {
               setActiveDevice(device);

--- a/frontend/app/version.js
+++ b/frontend/app/version.js
@@ -9,6 +9,8 @@ export const CHANGELOG_ENTRIES = [
     items: [
       'Reduced SQLite database lock errors in Docker by enabling a longer busy timeout and WAL mode.',
       'Prevented scheduled activity cleanup from running at the same time as the startup scan.',
+      'Improved Docker dashboard and page navigation speed by loading activity history only when needed.',
+      'Added database indexes for scan history, events, and notification history.',
     ],
   },
   {

--- a/macos/LanGuardMac/Packaging/Info.plist
+++ b/macos/LanGuardMac/Packaging/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.7</string>
+	<string>1.3.1</string>
 	<key>CFBundleVersion</key>
-	<string>28</string>
+	<string>29</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/macos/LanGuardMac/README.md
+++ b/macos/LanGuardMac/README.md
@@ -49,7 +49,7 @@ The app bundle is created at `.build/app/LanGuard.app`.
 
 ```bash
 ./Scripts/build_dmg.sh
-open .build/release/LanGuard-1.1.7.dmg
+open .build/release/LanGuard-1.3.1.dmg
 ```
 
 Drag `LanGuard.app` into `Applications` from the DMG window.

--- a/macos/LanGuardMac/Sources/LanGuardMac/HeaderView.swift
+++ b/macos/LanGuardMac/Sources/LanGuardMac/HeaderView.swift
@@ -95,7 +95,7 @@ enum AppVersion {
     static var current: String {
         let bundleVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
         let normalizedVersion = bundleVersion?.trimmingCharacters(in: .whitespacesAndNewlines)
-        return normalizedVersion?.isEmpty == false ? normalizedVersion! : "1.1.7"
+        return normalizedVersion?.isEmpty == false ? normalizedVersion! : "1.3.1"
     }
 }
 

--- a/macos/LanGuardMac/Sources/LanGuardMac/Services/VersionUpdateChecker.swift
+++ b/macos/LanGuardMac/Sources/LanGuardMac/Services/VersionUpdateChecker.swift
@@ -7,10 +7,11 @@ struct VersionUpdateStatus: Equatable {
 }
 
 enum VersionUpdateChecker {
-    private static let latestReleaseAPIURL = URL(string: "https://api.github.com/repos/hillaliy/LanGuard/releases/latest")!
+    private static let releasesAPIURL = URL(string: "https://api.github.com/repos/hillaliy/LanGuard/releases?per_page=20")!
+    private static let releasesPageURL = URL(string: "https://github.com/hillaliy/LanGuard/releases")!
 
     static func check(currentVersion: String) async throws -> VersionUpdateStatus {
-        var request = URLRequest(url: latestReleaseAPIURL)
+        var request = URLRequest(url: releasesAPIURL)
         request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
         request.setValue("LanGuardMac", forHTTPHeaderField: "User-Agent")
 
@@ -21,7 +22,15 @@ enum VersionUpdateChecker {
             throw VersionUpdateError.badResponse
         }
 
-        let release = try JSONDecoder().decode(GitHubReleaseResponse.self, from: data)
+        let releases = try JSONDecoder().decode([GitHubReleaseResponse].self, from: data)
+        guard let release = releases.first(where: isMacRelease) else {
+            return VersionUpdateStatus(
+                latestVersion: normalizedVersionString(currentVersion),
+                releaseURL: releasesPageURL,
+                isUpdateAvailable: false
+            )
+        }
+
         let latestVersion = normalizedVersionString(release.tagName)
 
         return VersionUpdateStatus(
@@ -67,6 +76,39 @@ enum VersionUpdateChecker {
 
         return components.isEmpty ? [0] : components
     }
+
+    static func isMacRelease(
+        body: String?,
+        assetNames: [String],
+        isDraft: Bool = false,
+        isPrerelease: Bool = false
+    ) -> Bool {
+        if isDraft || isPrerelease {
+            return false
+        }
+
+        let hasMacDownload = assetNames.contains { assetName in
+            assetName.lowercased().hasSuffix(".dmg")
+        }
+        if hasMacDownload {
+            return true
+        }
+
+        let bodyText = (body ?? "").lowercased()
+        return !bodyText.contains("no new macos app build")
+            && !bodyText.contains("same macos app as")
+            && !bodyText.contains("docker/web only")
+            && !bodyText.contains("docker only")
+    }
+
+    private static func isMacRelease(_ release: GitHubReleaseResponse) -> Bool {
+        isMacRelease(
+            body: release.body,
+            assetNames: release.assets.map(\.name),
+            isDraft: release.isDraft,
+            isPrerelease: release.isPrerelease
+        )
+    }
 }
 
 private enum VersionUpdateError: Error {
@@ -76,9 +118,21 @@ private enum VersionUpdateError: Error {
 private struct GitHubReleaseResponse: Decodable {
     let tagName: String
     let htmlURL: URL
+    let body: String?
+    let isDraft: Bool
+    let isPrerelease: Bool
+    let assets: [GitHubReleaseAsset]
 
     private enum CodingKeys: String, CodingKey {
         case tagName = "tag_name"
         case htmlURL = "html_url"
+        case body
+        case isDraft = "draft"
+        case isPrerelease = "prerelease"
+        case assets
     }
+}
+
+private struct GitHubReleaseAsset: Decodable {
+    let name: String
 }

--- a/macos/LanGuardMac/Tests/LanGuardMacTests/VersionUpdateCheckerTests.swift
+++ b/macos/LanGuardMac/Tests/LanGuardMacTests/VersionUpdateCheckerTests.swift
@@ -24,3 +24,41 @@ func versionUpdateCheckerNormalizesReleaseTags() {
     #expect(VersionUpdateChecker.normalizedVersionString("v1.0.16") == "1.0.16")
     #expect(VersionUpdateChecker.normalizedVersionString(" V1.0.16 ") == "1.0.16")
 }
+
+@Test
+func versionUpdateCheckerAcceptsMacReleaseWithDMGAsset() {
+    #expect(VersionUpdateChecker.isMacRelease(
+        body: "## macOS\n- New native app build.",
+        assetNames: ["LanGuard-1.3.1.dmg"]
+    ))
+}
+
+@Test
+func versionUpdateCheckerIgnoresDockerOnlyRelease() {
+    #expect(!VersionUpdateChecker.isMacRelease(
+        body: "## Docker/web\n- Fix Docker images.\n\n## macOS\n- No new macOS app build in this release.",
+        assetNames: []
+    ))
+}
+
+@Test
+func versionUpdateCheckerAcceptsUnmarkedReleaseWithoutDMGAsset() {
+    #expect(VersionUpdateChecker.isMacRelease(
+        body: "## macOS\n- Notes only.",
+        assetNames: []
+    ))
+}
+
+@Test
+func versionUpdateCheckerIgnoresDraftAndPrereleaseBuilds() {
+    #expect(!VersionUpdateChecker.isMacRelease(
+        body: "## macOS\n- Draft build.",
+        assetNames: ["LanGuard-1.3.2.dmg"],
+        isDraft: true
+    ))
+    #expect(!VersionUpdateChecker.isMacRelease(
+        body: "## macOS\n- Prerelease build.",
+        assetNames: ["LanGuard-1.3.2.dmg"],
+        isPrerelease: true
+    ))
+}


### PR DESCRIPTION
## Summary
- publish Docker/frontend performance fixes as part of 1.3.1
- add activity table indexes and lazy activity-history loading
- align macOS app to 1.3.1 and ignore Docker/web-only releases

## Checks
- .venv/bin/python backend/manage.py test core
- npm run lint
- npm run build
- swift test
- ./Scripts/build_dmg.sh