### PR TITLE
Release LanGuard 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.7.0 - 2026-08-28
+
+- Added device identity confidence and source evidence for hostname and vendor detection in Docker and macOS.
+- Preserved hostname and vendor source metadata when exporting or importing device inventories.
+- Added configurable quiet-hour weekdays in Docker and macOS, including correct handling for overnight ranges.
+- Fixed Docker device-list sizing to avoid unnecessary horizontal scrolling at narrower widths.
+- Updated Docker and macOS device rows to show `First Seen` when the list is sorted by first-seen time.
+
 ## 1.6.0 - 2026-08-26
 
 - Added per-channel test actions for configured Discord and Telegram notifications.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 <p align="center">
-  <img alt="Version" src="https://img.shields.io/badge/version-1.6.0-2496ed?style=for-the-badge">
+  <img alt="Version" src="https://img.shields.io/badge/version-1.7.0-2496ed?style=for-the-badge">
   <a href="https://github.com/hillaliy/LanGuard/pkgs/container/languard-backend">
     <img alt="Docker pulls" src="https://ghcr-badge.elias.eu.org/shield/hillaliy/LanGuard/languard-backend">
   </a>
@@ -129,7 +129,7 @@ The scanner waits for the configured scan interval after a scan completes before
 If you override `DISCORD_ICON_URL`, use a versioned URL when replacing the icon so Discord mobile clients do not reuse an old cached image, for example:
 
 ```env
-DISCORD_ICON_URL=https://raw.githubusercontent.com/hillaliy/LanGuard/main/frontend/public/logo.png?v=1.6.0
+DISCORD_ICON_URL=https://raw.githubusercontent.com/hillaliy/LanGuard/main/frontend/public/logo.png?v=1.7.0
 ```
 
 Portainer will create the stack network automatically.

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -67,7 +67,7 @@ def validate_production_settings(environment, secret_key, debug, allowed_hosts):
 BASE_DIR = Path(__file__).resolve().parent.parent
 
 ENVIRONMENT = os.getenv("ENVIRONMENT", "development").strip().lower()
-APP_VERSION = os.getenv("APP_VERSION", "1.6.0")
+APP_VERSION = os.getenv("APP_VERSION", "1.7.0")
 LATEST_VERSION_URL = os.getenv(
     "LATEST_VERSION_URL",
     "https://raw.githubusercontent.com/hillaliy/LanGuard/main/frontend/package.json",

--- a/backend/core/migrations/0019_appsettings_notification_quiet_hours_days.py
+++ b/backend/core/migrations/0019_appsettings_notification_quiet_hours_days.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+import core.models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0018_device_external_url"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="appsettings",
+            name="notification_quiet_hours_days",
+            field=models.JSONField(
+                blank=True,
+                default=core.models.default_quiet_hours_days,
+            ),
+        ),
+    ]

--- a/backend/core/migrations/0020_device_identity_sources.py
+++ b/backend/core/migrations/0020_device_identity_sources.py
@@ -1,0 +1,54 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0019_appsettings_notification_quiet_hours_days"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="device",
+            name="hostname_source",
+            field=models.CharField(
+                blank=True,
+                choices=[
+                    ("reverse_dns", "Reverse DNS"),
+                    ("mdns", "mDNS"),
+                    ("llmnr", "LLMNR"),
+                    ("netbios", "NetBIOS"),
+                    ("ssdp", "SSDP / UPnP"),
+                    ("snmp", "SNMP"),
+                    ("http", "Device web interface"),
+                    ("arp", "ARP"),
+                    ("manuf", "Wireshark manuf"),
+                    ("inferred", "Inferred"),
+                    ("imported", "Imported inventory"),
+                ],
+                default="",
+                max_length=32,
+            ),
+        ),
+        migrations.AddField(
+            model_name="device",
+            name="vendor_source",
+            field=models.CharField(
+                blank=True,
+                choices=[
+                    ("reverse_dns", "Reverse DNS"),
+                    ("mdns", "mDNS"),
+                    ("llmnr", "LLMNR"),
+                    ("netbios", "NetBIOS"),
+                    ("ssdp", "SSDP / UPnP"),
+                    ("snmp", "SNMP"),
+                    ("http", "Device web interface"),
+                    ("arp", "ARP"),
+                    ("manuf", "Wireshark manuf"),
+                    ("inferred", "Inferred"),
+                    ("imported", "Imported inventory"),
+                ],
+                default="",
+                max_length=32,
+            ),
+        ),
+    ]

--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -3,7 +3,27 @@ from django.conf import settings
 from django.utils import timezone
 
 
+QUIET_HOURS_DAY_KEYS = ("mon", "tue", "wed", "thu", "fri", "sat", "sun")
+
+
+def default_quiet_hours_days():
+    return list(QUIET_HOURS_DAY_KEYS)
+
+
 class Device(models.Model):
+    class IdentitySource(models.TextChoices):
+        REVERSE_DNS = "reverse_dns", "Reverse DNS"
+        MDNS = "mdns", "mDNS"
+        LLMNR = "llmnr", "LLMNR"
+        NETBIOS = "netbios", "NetBIOS"
+        SSDP = "ssdp", "SSDP / UPnP"
+        SNMP = "snmp", "SNMP"
+        HTTP = "http", "Device web interface"
+        ARP = "arp", "ARP"
+        MANUF = "manuf", "Wireshark manuf"
+        INFERRED = "inferred", "Inferred"
+        IMPORTED = "imported", "Imported inventory"
+
     class Status(models.TextChoices):
         ONLINE = "online", "Online"
         RECENTLY_SEEN = "recently_seen", "Recently seen"
@@ -21,9 +41,21 @@ class Device(models.Model):
     secondary_icon = models.CharField(max_length=255, blank=True, default="")
     name = models.CharField(max_length=100, default="Device")
     hostname = models.CharField(max_length=255, blank=True, default="")
+    hostname_source = models.CharField(
+        max_length=32,
+        choices=IdentitySource.choices,
+        blank=True,
+        default="",
+    )
     ip = models.GenericIPAddressField()
     mac = models.CharField(max_length=17, unique=True)
     vendor = models.CharField(max_length=255, blank=True, default="")
+    vendor_source = models.CharField(
+        max_length=32,
+        choices=IdentitySource.choices,
+        blank=True,
+        default="",
+    )
     comments = models.TextField(blank=True, default="")
     external_url = models.URLField(max_length=2048, blank=True, default="")
     attention_acknowledged_signature = models.CharField(max_length=64, blank=True, default="")
@@ -216,6 +248,10 @@ class AppSettings(models.Model):
     notification_quiet_hours_enabled = models.BooleanField(default=False)
     notification_quiet_hours_start = models.CharField(max_length=5, default="22:00")
     notification_quiet_hours_end = models.CharField(max_length=5, default="07:00")
+    notification_quiet_hours_days = models.JSONField(
+        default=default_quiet_hours_days,
+        blank=True,
+    )
     activity_cleanup_retention_days = models.PositiveIntegerField(default=90)
     home_map_layout = models.JSONField(default=dict, blank=True)
     updated_at = models.DateTimeField(auto_now=True)
@@ -250,6 +286,7 @@ class AppSettings(models.Model):
             "notification_quiet_hours_enabled": False,
             "notification_quiet_hours_start": "22:00",
             "notification_quiet_hours_end": "07:00",
+            "notification_quiet_hours_days": default_quiet_hours_days(),
             "activity_cleanup_retention_days": 90,
             "home_map_layout": {},
         }

--- a/backend/core/notifications.py
+++ b/backend/core/notifications.py
@@ -7,7 +7,12 @@ from django.conf import settings
 from django.utils import timezone
 
 from .datetime_utils import utc_isoformat
-from .models import AppSettings, NetworkEvent, NotificationDelivery
+from .models import (
+    AppSettings,
+    NetworkEvent,
+    NotificationDelivery,
+    QUIET_HOURS_DAY_KEYS,
+)
 
 
 LOGGER = logging.getLogger(__name__)
@@ -16,8 +21,6 @@ DISCORD_TEST_COLOR = 0x228BE6
 TEST_NOTIFICATION_MESSAGE = (
     "This is a test notification from LanGuard. Your notification channel is working."
 )
-
-
 def configured_channels(app_config=None):
     app_config = app_config or AppSettings.load()
     channels = []
@@ -60,9 +63,18 @@ def quiet_hours_active(app_config, now=None):
 
     if timezone.is_naive(now):
         now = timezone.make_aware(now, app_timezone)
-    local_time = timezone.localtime(now, app_timezone).time()
+    local_now = timezone.localtime(now, app_timezone)
+    local_time = local_now.time()
     start = time.fromisoformat(app_config.notification_quiet_hours_start)
     end = time.fromisoformat(app_config.notification_quiet_hours_end)
+    selected_days = app_config.notification_quiet_hours_days
+
+    quiet_period_weekday = local_now.weekday()
+    if start > end and local_time < end:
+        quiet_period_weekday = (quiet_period_weekday - 1) % 7
+    if QUIET_HOURS_DAY_KEYS[quiet_period_weekday] not in selected_days:
+        return False
+
     if start == end:
         return True
     if start < end:

--- a/backend/core/scan.py
+++ b/backend/core/scan.py
@@ -783,23 +783,46 @@ def detect_web_interface(ip, open_ports, timeout=1.2):
     return ""
 
 
-def get_hostname(ip, hostname_hints=None):
-    lookup_steps = [reverse_dns_hostname, mdns_reverse_hostname]
+def get_hostname(ip, hostname_hints=None, include_source=False):
+    lookup_steps = [
+        (Device.IdentitySource.REVERSE_DNS, reverse_dns_hostname),
+        (Device.IdentitySource.MDNS, mdns_reverse_hostname),
+    ]
     if hostname_hints is None:
-        lookup_steps.extend((mdns_service_hostname, llmnr_reverse_hostname, ssdp_hostname))
+        lookup_steps.extend((
+            (Device.IdentitySource.MDNS, mdns_service_hostname),
+            (Device.IdentitySource.LLMNR, llmnr_reverse_hostname),
+            (Device.IdentitySource.SSDP, ssdp_hostname),
+        ))
     else:
-        lookup_steps.extend((lambda address: hostname_hints.get(address, ""), llmnr_reverse_hostname))
-    lookup_steps.append(netbios_hostname)
-    for lookup in lookup_steps:
+        def hinted_hostname(address):
+            hint = hostname_hints.get(address, "")
+            return hint[0] if isinstance(hint, tuple) else hint
+
+        lookup_steps.extend((
+            ("hint", hinted_hostname),
+            (Device.IdentitySource.LLMNR, llmnr_reverse_hostname),
+        ))
+    lookup_steps.append((Device.IdentitySource.NETBIOS, netbios_hostname))
+    for source, lookup in lookup_steps:
         hostname = lookup(ip)
         if hostname:
-            return hostname
-    return ""
+            if source == "hint":
+                hint = hostname_hints.get(ip, "")
+                source = hint[1] if isinstance(hint, tuple) else ""
+            return (hostname, source) if include_source else hostname
+    return ("", "") if include_source else ""
 
 
 def discover_hostname_hints():
-    hints = ssdp_hostname_map()
-    hints.update(mdns_service_hostname_map())
+    hints = {
+        ip: (hostname, Device.IdentitySource.SSDP)
+        for ip, hostname in ssdp_hostname_map().items()
+    }
+    hints.update({
+        ip: (hostname, Device.IdentitySource.MDNS)
+        for ip, hostname in mdns_service_hostname_map().items()
+    })
     return hints
 
 
@@ -1397,7 +1420,12 @@ def sync_discovered_device(
     mac = element[1].hwsrc.lower()
     vendor = ManufDA.lookup(oui, mac) if oui else None
     vendor_name = manuf_vendor(mac) or (vendor[1] if vendor else "")
-    hostname = get_hostname(ip=ip, hostname_hints=hostname_hints)
+    hostname_result = get_hostname(ip=ip, hostname_hints=hostname_hints, include_source=True)
+    if isinstance(hostname_result, tuple):
+        hostname, hostname_source = hostname_result
+    else:
+        hostname, hostname_source = hostname_result, ""
+    vendor_source = Device.IdentitySource.MANUF if vendor_name else ""
     ports_opened = 0
     ports_closed = 0
     new_devices = 0
@@ -1424,12 +1452,20 @@ def sync_discovered_device(
         if device.hostname != resolved_hostname:
             device.hostname = resolved_hostname
             update_fields.append("hostname")
+        resolved_hostname_source = hostname_source if resolved_hostname else ""
+        if device.hostname_source != resolved_hostname_source:
+            device.hostname_source = resolved_hostname_source
+            update_fields.append("hostname_source")
         resolved_vendor = preferred_vendor(
             observed_vendor=vendor_name,
         )
         if resolved_vendor != device.vendor:
             device.vendor = resolved_vendor
             update_fields.append("vendor")
+        resolved_vendor_source = vendor_source if resolved_vendor else ""
+        if device.vendor_source != resolved_vendor_source:
+            device.vendor_source = resolved_vendor_source
+            update_fields.append("vendor_source")
         if is_gateway and device.role != "gateway":
             device.role = "gateway"
             update_fields.append("role")
@@ -1479,7 +1515,9 @@ def sync_discovered_device(
             ip=ip,
             mac=mac,
             vendor=resolved_vendor,
+            vendor_source=vendor_source if resolved_vendor else "",
             hostname=hostname[:255] if hostname else "",
+            hostname_source=hostname_source if hostname else "",
             role="gateway" if is_gateway else "device",
             known=is_gateway,
             is_gateway=is_gateway,

--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -11,6 +11,7 @@ from .models import (
     DevicePort,
     NetworkEvent,
     NotificationDelivery,
+    QUIET_HOURS_DAY_KEYS,
     ScanRun,
 )
 
@@ -130,6 +131,71 @@ ROLE_EXPECTED_PORTS = {
 }
 PORT_DENSE_ROLES = {"camera", "intercom", "server"}
 
+HIGH_CONFIDENCE_IDENTITY_SOURCES = {
+    Device.IdentitySource.REVERSE_DNS,
+    Device.IdentitySource.MDNS,
+    Device.IdentitySource.LLMNR,
+    Device.IdentitySource.NETBIOS,
+    Device.IdentitySource.SNMP,
+    Device.IdentitySource.MANUF,
+}
+MEDIUM_CONFIDENCE_IDENTITY_SOURCES = {
+    Device.IdentitySource.SSDP,
+    Device.IdentitySource.HTTP,
+    Device.IdentitySource.ARP,
+    Device.IdentitySource.IMPORTED,
+}
+
+
+def identity_field_confidence(value, source):
+    if not (value or "").strip():
+        return "none"
+    if source in HIGH_CONFIDENCE_IDENTITY_SOURCES:
+        return "high"
+    if source in MEDIUM_CONFIDENCE_IDENTITY_SOURCES:
+        return "medium"
+    return "low"
+
+
+def device_identity(device):
+    hostname_confidence = identity_field_confidence(device.hostname, device.hostname_source)
+    vendor_confidence = identity_field_confidence(device.vendor, device.vendor_source)
+    field_confidences = {hostname_confidence, vendor_confidence}
+
+    if hostname_confidence == "high" and vendor_confidence == "high":
+        confidence = "high"
+    elif "high" in field_confidences or (
+        hostname_confidence == "medium" and vendor_confidence == "medium"
+    ):
+        confidence = "medium"
+    else:
+        confidence = "low"
+
+    evidence = []
+    if device.hostname:
+        evidence.append({
+            "field": "hostname",
+            "value": device.hostname,
+            "source": device.hostname_source,
+            "source_display": device.get_hostname_source_display() if device.hostname_source else "Unknown",
+            "confidence": hostname_confidence,
+        })
+    if device.vendor:
+        evidence.append({
+            "field": "vendor",
+            "value": device.vendor,
+            "source": device.vendor_source,
+            "source_display": device.get_vendor_source_display() if device.vendor_source else "Unknown",
+            "confidence": vendor_confidence,
+        })
+
+    return {
+        "confidence": confidence,
+        "hostname_confidence": hostname_confidence,
+        "vendor_confidence": vendor_confidence,
+        "evidence": evidence,
+    }
+
 
 def device_risk(device):
     score = 0
@@ -217,6 +283,8 @@ def device_needs_attention(device, risk_data=None):
 
 
 class DeviceSerializer(serializers.ModelSerializer):
+    hostname_source = serializers.CharField(read_only=True)
+    vendor_source = serializers.CharField(read_only=True)
     attention_acknowledged_signature = serializers.HiddenField(
         default=serializers.CreateOnlyDefault("")
     )
@@ -230,6 +298,10 @@ class DeviceSerializer(serializers.ModelSerializer):
     risk_reasons = serializers.SerializerMethodField()
     attention_acknowledged = serializers.SerializerMethodField()
     needs_attention = serializers.SerializerMethodField()
+    identity_confidence = serializers.SerializerMethodField()
+    hostname_confidence = serializers.SerializerMethodField()
+    vendor_confidence = serializers.SerializerMethodField()
+    identity_evidence = serializers.SerializerMethodField()
     acknowledge_attention = serializers.BooleanField(write_only=True, required=False)
     status_display = serializers.CharField(
         source="get_status_display",
@@ -243,6 +315,28 @@ class DeviceSerializer(serializers.ModelSerializer):
     class Meta:
         model = Device
         fields = "__all__"
+        read_only_fields = ("hostname", "vendor", "hostname_source", "vendor_source")
+
+    def get_device_identity(self, obj):
+        if not hasattr(obj, "_identity_data"):
+            obj._identity_data = device_identity(obj)
+        return obj._identity_data
+
+    @extend_schema_field(serializers.CharField)
+    def get_identity_confidence(self, obj):
+        return self.get_device_identity(obj)["confidence"]
+
+    @extend_schema_field(serializers.CharField)
+    def get_hostname_confidence(self, obj):
+        return self.get_device_identity(obj)["hostname_confidence"]
+
+    @extend_schema_field(serializers.CharField)
+    def get_vendor_confidence(self, obj):
+        return self.get_device_identity(obj)["vendor_confidence"]
+
+    @extend_schema_field(serializers.ListField(child=serializers.DictField()))
+    def get_identity_evidence(self, obj):
+        return self.get_device_identity(obj)["evidence"]
 
     def validate_external_url(self, value):
         value = (value or "").strip()
@@ -410,6 +504,7 @@ class AppSettingsSerializer(serializers.ModelSerializer):
             "notification_quiet_hours_enabled",
             "notification_quiet_hours_start",
             "notification_quiet_hours_end",
+            "notification_quiet_hours_days",
             "activity_cleanup_retention_days",
             "home_map_layout",
             "updated_at",
@@ -476,6 +571,15 @@ class AppSettingsSerializer(serializers.ModelSerializer):
 
     def validate_notification_quiet_hours_end(self, value):
         return self.validate_quiet_hour(value)
+
+    def validate_notification_quiet_hours_days(self, value):
+        if not isinstance(value, list):
+            raise serializers.ValidationError("Select days as a list.")
+        if len(value) != len(set(value)):
+            raise serializers.ValidationError("Each day can only be selected once.")
+        if any(day not in QUIET_HOURS_DAY_KEYS for day in value):
+            raise serializers.ValidationError("Select valid weekdays.")
+        return [day for day in QUIET_HOURS_DAY_KEYS if day in value]
 
     def validate_quiet_hour(self, value):
         import datetime

--- a/backend/core/tests.py
+++ b/backend/core/tests.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone as datetime_timezone
 import socket
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
@@ -24,10 +24,12 @@ from .models import (
 from .notifications import (
     format_discord_payload,
     notify_event,
+    quiet_hours_active,
     retry_failed_notifications,
     send_discord_test,
     send_telegram_test,
 )
+from .serializers import device_identity
 from .views import parse_inventory_datetime
 from .scan import (
     clear_stale_gateways,
@@ -130,6 +132,10 @@ class HostnameResolutionTests(SimpleTestCase):
     @patch("core.scan.socket.gethostbyaddr", side_effect=socket.herror)
     def test_get_hostname_uses_mdns_fallback(self, *_):
         self.assertEqual(get_hostname("192.168.1.21"), "haa switch")
+        self.assertEqual(
+            get_hostname("192.168.1.21", include_source=True),
+            ("haa switch", Device.IdentitySource.MDNS),
+        )
 
     @patch("core.scan.netbios_hostname", return_value="")
     @patch("core.scan.ssdp_hostname", return_value="")
@@ -189,6 +195,17 @@ class HostnameResolutionTests(SimpleTestCase):
             "HAA 123456",
         )
 
+    def test_preloaded_hint_preserves_discovery_source(self):
+        self.assertEqual(
+            get_hostname(
+                "192.168.1.42",
+                hostname_hints={
+                    "192.168.1.42": ("HAA 123456", Device.IdentitySource.MDNS)
+                },
+                include_source=True,
+            ),
+            ("HAA 123456", Device.IdentitySource.MDNS),
+        )
     def test_dns_ptr_names_returns_matching_owner(self):
         packet = (
             b"\x00\x00\x84\x00\x00\x00\x00\x01\x00\x00\x00\x00"
@@ -442,6 +459,42 @@ class HostnameResolutionTests(SimpleTestCase):
 
     def test_manuf_vendor_ignores_locally_administered_mac(self):
         self.assertEqual(manuf_vendor("f6:34:f0:00:c6:8d"), "")
+
+
+class DeviceIdentityConfidenceTests(TestCase):
+    def test_high_confidence_requires_strong_hostname_and_vendor_sources(self):
+        device = Device.objects.create(
+            name="Living room streamer",
+            ip="192.168.1.20",
+            mac="90:dd:5d:b7:bd:01",
+            hostname="living room streamer",
+            hostname_source=Device.IdentitySource.MDNS,
+            vendor="Apple, Inc.",
+            vendor_source=Device.IdentitySource.MANUF,
+        )
+
+        identity = device_identity(device)
+
+        self.assertEqual(identity["confidence"], "high")
+        self.assertEqual(identity["hostname_confidence"], "high")
+        self.assertEqual(identity["vendor_confidence"], "high")
+        self.assertEqual(
+            [item["source_display"] for item in identity["evidence"]],
+            ["mDNS", "Wireshark manuf"],
+        )
+
+    def test_unknown_legacy_sources_are_not_overstated(self):
+        device = Device.objects.create(
+            name="Imported device",
+            ip="192.168.1.21",
+            mac="90:dd:5d:b7:bd:02",
+            vendor="Example vendor",
+        )
+
+        identity = device_identity(device)
+
+        self.assertEqual(identity["confidence"], "low")
+        self.assertEqual(identity["vendor_confidence"], "low")
 
 
 class ApiDocsAccessTests(SimpleTestCase):
@@ -1176,6 +1229,38 @@ class NotificationTests(TestCase):
             message="Found new device Camera at 192.168.1.50",
         )
 
+    def test_quiet_hours_only_apply_on_selected_day(self):
+        config = AppSettings(
+            time_zone="UTC",
+            notification_quiet_hours_enabled=True,
+            notification_quiet_hours_start="09:00",
+            notification_quiet_hours_end="17:00",
+            notification_quiet_hours_days=["mon"],
+        )
+
+        monday = datetime(2026, 8, 24, 12, 0, tzinfo=datetime_timezone.utc)
+        tuesday = datetime(2026, 8, 25, 12, 0, tzinfo=datetime_timezone.utc)
+
+        self.assertTrue(quiet_hours_active(config, now=monday))
+        self.assertFalse(quiet_hours_active(config, now=tuesday))
+
+    def test_overnight_quiet_hours_use_the_starting_day(self):
+        config = AppSettings(
+            time_zone="UTC",
+            notification_quiet_hours_enabled=True,
+            notification_quiet_hours_start="22:00",
+            notification_quiet_hours_end="07:00",
+            notification_quiet_hours_days=["mon"],
+        )
+
+        monday_night = datetime(2026, 8, 24, 23, 0, tzinfo=datetime_timezone.utc)
+        tuesday_morning = datetime(2026, 8, 25, 2, 0, tzinfo=datetime_timezone.utc)
+        tuesday_night = datetime(2026, 8, 25, 23, 0, tzinfo=datetime_timezone.utc)
+
+        self.assertTrue(quiet_hours_active(config, now=monday_night))
+        self.assertTrue(quiet_hours_active(config, now=tuesday_morning))
+        self.assertFalse(quiet_hours_active(config, now=tuesday_night))
+
     @override_settings(
         NOTIFICATIONS_ENABLED=True,
         DISCORD_WEBHOOK="https://discord.example/webhook",
@@ -1847,6 +1932,7 @@ class ScanApiTests(TestCase):
                 "notification_quiet_hours_enabled": True,
                 "notification_quiet_hours_start": "23:00",
                 "notification_quiet_hours_end": "06:30",
+                "notification_quiet_hours_days": ["sun", "mon", "wed"],
                 "activity_cleanup_retention_days": 45,
                 "discord_webhook": "https://discord.example/webhook",
                 "telegram_token": "token",
@@ -1874,6 +1960,7 @@ class ScanApiTests(TestCase):
         self.assertTrue(config.notification_quiet_hours_enabled)
         self.assertEqual(config.notification_quiet_hours_start, "23:00")
         self.assertEqual(config.notification_quiet_hours_end, "06:30")
+        self.assertEqual(config.notification_quiet_hours_days, ["mon", "wed", "sun"])
         self.assertEqual(config.activity_cleanup_retention_days, 45)
         self.assertEqual(
             config.home_map_layout,
@@ -1898,6 +1985,10 @@ class ScanApiTests(TestCase):
         self.assertTrue(response.data["data"]["notification_quiet_hours_enabled"])
         self.assertEqual(response.data["data"]["notification_quiet_hours_start"], "23:00")
         self.assertEqual(response.data["data"]["notification_quiet_hours_end"], "06:30")
+        self.assertEqual(
+            response.data["data"]["notification_quiet_hours_days"],
+            ["mon", "wed", "sun"],
+        )
         self.assertEqual(response.data["data"]["activity_cleanup_retention_days"], 45)
         self.assertEqual(
             response.data["data"]["home_map_layout"],
@@ -1923,6 +2014,16 @@ class ScanApiTests(TestCase):
 
         self.assertEqual(response.status_code, 400)
         self.assertIn("notification_quiet_hours_start", response.data)
+
+    def test_settings_endpoint_rejects_bad_quiet_hours_days(self):
+        response = self.client.put(
+            "/api/v1/settings/",
+            {"notification_quiet_hours_days": ["mon", "someday"]},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("notification_quiet_hours_days", response.data)
 
     @override_settings(SCAN_MAX_HOSTS=256, SCAN_ALLOW_PUBLIC_RANGES=False)
     def test_settings_endpoint_rejects_unsafe_scan_range(self):

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -300,7 +300,9 @@ def inventory_device_payload(device):
         "ip": device.ip,
         "mac": device.mac,
         "vendor": device.vendor,
+        "vendor_source": device.vendor_source,
         "hostname": getattr(device, "hostname", ""),
+        "hostname_source": device.hostname_source,
         "icon": export_inventory_icon(device.icon),
         "secondary_icon": export_inventory_icon(getattr(device, "secondary_icon", "")),
         "role": getattr(device, "role", "") or ("gateway" if device.is_gateway else "device"),
@@ -443,6 +445,18 @@ def import_inventory_devices(payload):
 
         name = str(item.get("name") or "Device").strip()[:100] or "Device"
         hostname = str(item.get("hostname") or item.get("hostName") or "").strip()[:255]
+        hostname_source = str(
+            item.get("hostname_source") or item.get("hostnameSource") or ""
+        ).strip()
+        vendor_source = str(
+            item.get("vendor_source") or item.get("vendorSource") or ""
+        ).strip()
+        valid_identity_sources = set(Device.IdentitySource.values)
+        if hostname_source not in valid_identity_sources:
+            hostname_source = Device.IdentitySource.IMPORTED if hostname else ""
+        imported_vendor = str(item.get("vendor") or "").strip()[:255]
+        if vendor_source not in valid_identity_sources:
+            vendor_source = Device.IdentitySource.IMPORTED if imported_vendor else ""
         comments_present = "comments" in item
         comments = str(item.get("comments") or "").strip()
         external_url_present = "external_url" in item or "externalUrl" in item
@@ -482,13 +496,15 @@ def import_inventory_devices(payload):
         defaults = {
             "name": name,
             "ip": ip,
-            "vendor": str(item.get("vendor") or "").strip()[:255],
+            "vendor": imported_vendor,
+            "vendor_source": vendor_source,
             "icon": import_inventory_icon(item.get("icon") or item.get("iconName")),
             "secondary_icon": import_inventory_icon(
                 item.get("secondary_icon") or item.get("secondaryIcon") or item.get("secondaryIconName"),
                 "",
             ),
             "hostname": hostname,
+            "hostname_source": hostname_source,
             "known": parse_inventory_bool(item.get("known", item.get("isKnown", False))),
             "is_gateway": is_gateway,
             "online": device_status != Device.Status.OFFLINE,
@@ -523,9 +539,11 @@ def import_inventory_devices(payload):
                     "name",
                     "ip",
                     "vendor",
+                    "vendor_source",
                     "icon",
                     "secondary_icon",
                     "hostname",
+                    "hostname_source",
                     *(['role'] if role is not None else []),
                     *(['room'] if room is not None else []),
                     *(["comments"] if comments_present else []),

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -541,9 +541,15 @@ textarea {
   background: color-mix(in srgb, var(--muted-panel-bg) 72%, transparent);
 }
 
+.devices-content-panel {
+  container-type: inline-size;
+}
+
 .device-list {
   max-height: min(760px, 72vh);
+  overflow-x: hidden;
   overflow-y: auto;
+  scrollbar-gutter: stable;
 }
 
 .device-list-row {
@@ -554,8 +560,8 @@ textarea {
   color: var(--field-text);
   cursor: pointer;
   display: grid;
-  gap: 16px;
-  grid-template-columns: minmax(250px, 1.1fr) minmax(760px, 2.4fr);
+  gap: 14px;
+  grid-template-columns: minmax(210px, 1.05fr) minmax(0, 2.75fr);
   letter-spacing: 0;
   min-width: 0;
   padding: 14px 18px;
@@ -600,15 +606,15 @@ textarea {
 .device-list-meta {
   align-items: center;
   display: grid;
-  gap: 12px;
+  gap: 10px;
   grid-template-columns:
-    minmax(96px, 0.75fr)
-    minmax(120px, 0.8fr)
-    minmax(90px, 0.7fr)
-    minmax(100px, 0.75fr)
+    minmax(76px, 0.65fr)
+    minmax(108px, 0.8fr)
+    minmax(70px, 0.65fr)
+    minmax(82px, 0.75fr)
     minmax(146px, 0.9fr)
-    minmax(82px, 0.6fr)
-    minmax(170px, 1.15fr);
+    minmax(64px, 0.55fr)
+    minmax(136px, 1.2fr);
   min-width: 0;
 }
 
@@ -631,12 +637,24 @@ textarea {
 }
 
 .device-list-last-seen {
-  min-width: 170px;
+  min-width: 0;
 }
 
 .device-list-last-seen-value {
   line-height: 1.25;
-  white-space: nowrap;
+  overflow-wrap: normal;
+  white-space: normal;
+}
+
+@container (max-width: 1030px) {
+  .devices-content-panel .device-list,
+  .devices-content-panel .device-list-toolbar {
+    display: none;
+  }
+
+  .devices-content-panel .device-mobile-list {
+    display: flex;
+  }
 }
 
 .devices-table {
@@ -1237,6 +1255,11 @@ textarea {
   border-radius: 8px;
   min-width: 0;
   padding: 10px 12px;
+}
+
+.identity-confidence-field {
+  grid-column: 1 / -1;
+  min-height: 74px;
 }
 
 .device-field.editable {

--- a/frontend/app/page.jsx
+++ b/frontend/app/page.jsx
@@ -8,6 +8,7 @@ import {
   Badge,
   Box,
   Button,
+  Checkbox,
   Container,
   Divider,
   FileButton,
@@ -267,6 +268,17 @@ const timeZoneOptions =
   typeof Intl !== 'undefined' && typeof Intl.supportedValuesOf === 'function'
     ? Intl.supportedValuesOf('timeZone')
     : fallbackTimeZoneOptions;
+
+const quietHoursDayOptions = [
+  { value: 'mon', label: 'Mon' },
+  { value: 'tue', label: 'Tue' },
+  { value: 'wed', label: 'Wed' },
+  { value: 'thu', label: 'Thu' },
+  { value: 'fri', label: 'Fri' },
+  { value: 'sat', label: 'Sat' },
+  { value: 'sun', label: 'Sun' },
+];
+const allQuietHoursDays = quietHoursDayOptions.map(({ value }) => value);
 
 function showSuccessNotification(title, message) {
   notifications.show({
@@ -2173,6 +2185,38 @@ function DeviceField({ label, value, editable = false, required = false, onChang
   );
 }
 
+function IdentityConfidenceField({ device }) {
+  const confidence = String(device?.identity_confidence || 'low').toLowerCase();
+  const evidence = Array.isArray(device?.identity_evidence) ? device.identity_evidence : [];
+  const color = confidence === 'high' ? 'green' : confidence === 'medium' ? 'yellow' : 'gray';
+  const label = confidence.charAt(0).toUpperCase() + confidence.slice(1);
+
+  return (
+    <Box className="device-field identity-confidence-field">
+      <Group justify="space-between" gap="xs" wrap="nowrap">
+        <Text size="xs" c="dimmed">Identity confidence</Text>
+        <Badge color={color} variant="light">{label}</Badge>
+      </Group>
+      {evidence.length > 0 ? (
+        <Stack gap={2} mt={4}>
+          {evidence.map((item) => (
+            <Group key={item.field} justify="space-between" gap="xs" wrap="nowrap">
+              <Text size="xs" className="wrap-text">
+                {item.field === 'hostname' ? 'Hostname' : 'Vendor'}: {item.source_display || 'Unknown'}
+              </Text>
+              <Text size="xs" c="dimmed">
+                {String(item.confidence || 'low').replace(/^./, (letter) => letter.toUpperCase())}
+              </Text>
+            </Group>
+          ))}
+        </Stack>
+      ) : (
+        <Text size="xs" c="dimmed" mt={4}>No identity evidence collected yet.</Text>
+      )}
+    </Box>
+  );
+}
+
 function buildRoomOptions(devices = [], currentRoom = '') {
   return Array.from(
     new Set(
@@ -2428,6 +2472,8 @@ function DeviceModal({ device, opened, onClose, onSaved, timeZone, roomOptions }
           <DeviceIconPicker value={icon} onChange={setIcon} />
           <DeviceIconPicker label="Secondary icon" value={secondaryIcon} onChange={setSecondaryIcon} />
         </SimpleGrid>
+
+        <IdentityConfidenceField device={device} />
 
         <Textarea
           label="Comments"
@@ -2904,6 +2950,7 @@ function SettingsPage({ onSaved }) {
   const [quietHoursEnabled, setQuietHoursEnabled] = useState(false);
   const [quietHoursStart, setQuietHoursStart] = useState('22:00');
   const [quietHoursEnd, setQuietHoursEnd] = useState('07:00');
+  const [quietHoursDays, setQuietHoursDays] = useState(allQuietHoursDays);
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
   const [testingChannel, setTestingChannel] = useState('');
@@ -2938,6 +2985,11 @@ function SettingsPage({ onSaved }) {
       setQuietHoursEnabled(Boolean(data.notification_quiet_hours_enabled));
       setQuietHoursStart(data.notification_quiet_hours_start || '22:00');
       setQuietHoursEnd(data.notification_quiet_hours_end || '07:00');
+      setQuietHoursDays(
+        Array.isArray(data.notification_quiet_hours_days)
+          ? data.notification_quiet_hours_days
+          : allQuietHoursDays
+      );
       setCleanupDays(Number(data.activity_cleanup_retention_days ?? 90));
     } catch (err) {
       setError(err.message);
@@ -2968,6 +3020,7 @@ function SettingsPage({ onSaved }) {
         notification_quiet_hours_enabled: quietHoursEnabled,
         notification_quiet_hours_start: quietHoursStart,
         notification_quiet_hours_end: quietHoursEnd,
+        notification_quiet_hours_days: quietHoursDays,
         activity_cleanup_retention_days: cleanupDays,
       };
       body.discord_webhook = discordWebhook;
@@ -3210,6 +3263,23 @@ function SettingsPage({ onSaved }) {
               disabled={!quietHoursEnabled}
             />
           </SimpleGrid>
+          <Checkbox.Group
+            label="Quiet days"
+            description="For overnight ranges, early morning hours belong to the previous day."
+            value={quietHoursDays}
+            onChange={setQuietHoursDays}
+          >
+            <Group mt="xs" gap="lg">
+              {quietHoursDayOptions.map((day) => (
+                <Checkbox
+                  key={day.value}
+                  value={day.value}
+                  label={day.label}
+                  disabled={!quietHoursEnabled}
+                />
+              ))}
+            </Group>
+          </Checkbox.Group>
         </Stack>
 
         <Divider />
@@ -3814,6 +3884,7 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
     ? `New version v${latestVersion} is available`
     : 'Version history';
   const displayTimeZone = appSettings?.time_zone || dashboardTimeZone || undefined;
+  const showFirstSeen = deviceOrdering === 'firstseen' || deviceOrdering === '-firstseen';
 
   useEffect(() => {
     tableStateRef.current = {
@@ -4395,7 +4466,7 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
             timeZone={displayTimeZone}
           />
 
-          <Paper className="content-panel" radius="md">
+          <Paper className="content-panel devices-content-panel" radius="md">
             <Stack gap={0}>
               <Group className="devices-panel-header" justify="space-between" p="md">
                 <Group>
@@ -4566,9 +4637,14 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
                             <RiskBadge device={device} compact />
                           </Box>
                           <Box className="device-list-last-seen">
-                            <Text size="xs" c="dimmed">Last seen</Text>
+                            <Text size="xs" c="dimmed">
+                              {showFirstSeen ? 'First seen' : 'Last seen'}
+                            </Text>
                             <Text className="device-list-last-seen-value">
-                              {formatDate(device.lastseen, displayTimeZone)}
+                              {formatDate(
+                                showFirstSeen ? device.firstseen : device.lastseen,
+                                displayTimeZone
+                              )}
                             </Text>
                           </Box>
                         </div>
@@ -4612,8 +4688,15 @@ function Dashboard({ user, onLogout, onUserUpdated }) {
                             <Text size="sm" className="mobile-mono-value">{device.ip}</Text>
                           </Box>
                           <Box>
-                            <Text size="xs" c="dimmed">Last seen</Text>
-                            <Text size="sm">{formatDate(device.lastseen, displayTimeZone)}</Text>
+                            <Text size="xs" c="dimmed">
+                              {showFirstSeen ? 'First seen' : 'Last seen'}
+                            </Text>
+                            <Text size="sm">
+                              {formatDate(
+                                showFirstSeen ? device.firstseen : device.lastseen,
+                                displayTimeZone
+                              )}
+                            </Text>
                           </Box>
                           <Box className="device-mobile-wide">
                             <Text size="xs" c="dimmed">Room</Text>

--- a/frontend/app/version.js
+++ b/frontend/app/version.js
@@ -4,6 +4,17 @@ export const APP_VERSION = packageInfo.version;
 
 export const CHANGELOG_ENTRIES = [
   {
+    version: '1.7.0',
+    date: '2026-08-28',
+    items: [
+      'Added device identity confidence and source evidence for hostname and vendor detection in Docker and macOS.',
+      'Preserved hostname and vendor source metadata when exporting or importing device inventories.',
+      'Added configurable quiet-hour weekdays in Docker and macOS, including correct handling for overnight ranges.',
+      'Fixed device-list sizing to avoid unnecessary horizontal scrolling at narrower widths.',
+      'Show First Seen in Docker and macOS device rows when sorting by first-seen time.',
+    ],
+  },
+  {
     version: '1.6.0',
     date: '2026-08-26',
     items: [

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "languard-frontend",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "languard-frontend",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "dependencies": {
         "@mantine/core": "^9.5.2",
         "@mantine/hooks": "^9.5.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "languard-frontend",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/macos/LanGuardMac/Packaging/Info.plist
+++ b/macos/LanGuardMac/Packaging/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.0</string>
+	<string>1.7.0</string>
 	<key>CFBundleVersion</key>
-	<string>32</string>
+	<string>33</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/macos/LanGuardMac/README.md
+++ b/macos/LanGuardMac/README.md
@@ -49,7 +49,7 @@ The app bundle is created at `.build/app/LanGuard.app`.
 
 ```bash
 ./Scripts/build_dmg.sh
-open .build/release/LanGuard-1.6.0.dmg
+open .build/release/LanGuard-1.7.0.dmg
 ```
 
 Drag `LanGuard.app` into `Applications` from the DMG window.

--- a/macos/LanGuardMac/Sources/LanGuardMac/DevicesView.swift
+++ b/macos/LanGuardMac/Sources/LanGuardMac/DevicesView.swift
@@ -68,7 +68,8 @@ struct DevicesView: View {
                             device: device,
                             portSummary: portSummary(for: device.openPorts),
                             roomTitle: roomTitle(for: device),
-                            riskColor: riskColor(for: device.risk)
+                            riskColor: riskColor(for: device.risk),
+                            showFirstSeen: sortField == .firstSeen
                         )
                     }
                     .buttonStyle(.plain)
@@ -324,7 +325,12 @@ struct DevicesView: View {
             Button {
                 editingDevice = device
             } label: {
-                CompactDeviceRow(device: device, portSummary: portSummary(for: device.openPorts), riskColor: riskColor(for: device.risk))
+                CompactDeviceRow(
+                    device: device,
+                    portSummary: portSummary(for: device.openPorts),
+                    riskColor: riskColor(for: device.risk),
+                    showFirstSeen: sortField == .firstSeen
+                )
             }
             .buttonStyle(.plain)
             .listRowInsets(EdgeInsets(top: 6, leading: 0, bottom: 6, trailing: 0))
@@ -541,6 +547,7 @@ private struct DeviceCardRow: View {
     let portSummary: String
     let roomTitle: String
     let riskColor: Color
+    let showFirstSeen: Bool
 
     var body: some View {
         HStack(spacing: 18) {
@@ -625,8 +632,8 @@ private struct DeviceCardRow: View {
             }
             .frame(width: 78, alignment: .leading)
 
-            DeviceMetaColumn(title: "Last seen") {
-                Text(device.lastSeen.formatted(date: .abbreviated, time: .shortened))
+            DeviceMetaColumn(title: showFirstSeen ? "First seen" : "Last seen") {
+                Text(seenDate.formatted(date: .abbreviated, time: .shortened))
                     .lineLimit(2)
                     .fixedSize(horizontal: false, vertical: true)
             }
@@ -642,6 +649,10 @@ private struct DeviceCardRow: View {
         DeviceNameGuesser.isMACAddressText(device.name)
             ? DeviceNameGuesser.displayName(hostname: nil, macAddress: device.macAddress)
             : device.name
+    }
+
+    private var seenDate: Date {
+        showFirstSeen ? device.firstSeen : device.lastSeen
     }
 
     private var subtitle: String {
@@ -682,6 +693,7 @@ private struct CompactDeviceRow: View {
     let device: NetworkDevice
     let portSummary: String
     let riskColor: Color
+    let showFirstSeen: Bool
 
     private var roomTitle: String {
         let room = device.room?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
@@ -762,8 +774,8 @@ private struct CompactDeviceRow: View {
             }
             .frame(width: 64, alignment: .leading)
 
-            DeviceCompactMeta(title: "Last seen") {
-                Text(device.lastSeen.formatted(date: .abbreviated, time: .shortened))
+            DeviceCompactMeta(title: showFirstSeen ? "First seen" : "Last seen") {
+                Text(seenDate.formatted(date: .abbreviated, time: .shortened))
             }
             .frame(width: 112, alignment: .leading)
 
@@ -835,8 +847,8 @@ private struct CompactDeviceRow: View {
                 }
                 .frame(width: 64, alignment: .leading)
 
-                DeviceCompactMeta(title: "Last seen") {
-                    Text(device.lastSeen.formatted(date: .abbreviated, time: .shortened))
+                DeviceCompactMeta(title: showFirstSeen ? "First seen" : "Last seen") {
+                    Text(seenDate.formatted(date: .abbreviated, time: .shortened))
                 }
                 .frame(width: 112, alignment: .leading)
             }
@@ -868,6 +880,10 @@ private struct CompactDeviceRow: View {
         DeviceNameGuesser.isMACAddressText(device.name)
             ? DeviceNameGuesser.displayName(hostname: nil, macAddress: device.macAddress)
             : device.name
+    }
+
+    private var seenDate: Date {
+        showFirstSeen ? device.firstSeen : device.lastSeen
     }
 
     private var subtitle: String {
@@ -1040,6 +1056,23 @@ struct DeviceDetailView: View {
                     DetailRow(title: "Risk", value: originalDevice.risk.title)
                 }
 
+                Section("Identity") {
+                    IdentityConfidenceRow(
+                        title: "Identity confidence",
+                        confidence: originalDevice.identityConfidence
+                    )
+                    IdentityEvidenceRow(
+                        title: "Hostname source",
+                        source: originalDevice.hostnameSource,
+                        confidence: originalDevice.hostnameConfidence
+                    )
+                    IdentityEvidenceRow(
+                        title: "Vendor source",
+                        source: originalDevice.vendorSource,
+                        confidence: originalDevice.vendorConfidence
+                    )
+                }
+
                 Section("Timeline") {
                     DetailRow(title: "First seen", value: originalDevice.firstSeen.formatted(date: .abbreviated, time: .shortened))
                     DetailRow(title: "Last seen", value: originalDevice.lastSeen.formatted(date: .abbreviated, time: .shortened))
@@ -1200,6 +1233,43 @@ private struct DetailRow: View {
                 .multilineTextAlignment(.trailing)
                 .textSelection(.enabled)
         }
+    }
+}
+
+private struct IdentityConfidenceRow: View {
+    let title: String
+    let confidence: DeviceIdentityConfidence
+
+    var body: some View {
+        LabeledContent(title) {
+            Text(confidence.title)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(confidenceColor)
+                .padding(.horizontal, 9)
+                .padding(.vertical, 4)
+                .background(confidenceColor.opacity(0.14), in: Capsule())
+        }
+    }
+
+    private var confidenceColor: Color {
+        switch confidence {
+        case .high: .green
+        case .medium: .orange
+        case .low, .none: .secondary
+        }
+    }
+}
+
+private struct IdentityEvidenceRow: View {
+    let title: String
+    let source: DeviceIdentitySource?
+    let confidence: DeviceIdentityConfidence
+
+    var body: some View {
+        DetailRow(
+            title: title,
+            value: source.map { "\($0.title) (\(confidence.title))" } ?? "Unknown"
+        )
     }
 }
 

--- a/macos/LanGuardMac/Sources/LanGuardMac/HeaderView.swift
+++ b/macos/LanGuardMac/Sources/LanGuardMac/HeaderView.swift
@@ -95,7 +95,7 @@ enum AppVersion {
     static var current: String {
         let bundleVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
         let normalizedVersion = bundleVersion?.trimmingCharacters(in: .whitespacesAndNewlines)
-        return normalizedVersion?.isEmpty == false ? normalizedVersion! : "1.6.0"
+        return normalizedVersion?.isEmpty == false ? normalizedVersion! : "1.7.0"
     }
 }
 

--- a/macos/LanGuardMac/Sources/LanGuardMac/Models/AppSettings.swift
+++ b/macos/LanGuardMac/Sources/LanGuardMac/Models/AppSettings.swift
@@ -1,5 +1,42 @@
 import Foundation
 
+enum QuietHoursWeekday: String, Codable, CaseIterable, Identifiable, Sendable {
+    case monday
+    case tuesday
+    case wednesday
+    case thursday
+    case friday
+    case saturday
+    case sunday
+
+    var id: String { rawValue }
+
+    var shortTitle: String {
+        switch self {
+        case .monday: "Mon"
+        case .tuesday: "Tue"
+        case .wednesday: "Wed"
+        case .thursday: "Thu"
+        case .friday: "Fri"
+        case .saturday: "Sat"
+        case .sunday: "Sun"
+        }
+    }
+
+    static func from(calendarWeekday: Int) -> Self? {
+        switch calendarWeekday {
+        case 1: .sunday
+        case 2: .monday
+        case 3: .tuesday
+        case 4: .wednesday
+        case 5: .thursday
+        case 6: .friday
+        case 7: .saturday
+        default: nil
+        }
+    }
+}
+
 struct AppSettings: Codable, Equatable, Sendable {
     var defaultScanRange: String
     var scanIntervalMinutes: Int
@@ -7,6 +44,10 @@ struct AppSettings: Codable, Equatable, Sendable {
     var scheduledScanningEnabled: Bool
     var newDeviceNotificationsEnabled: Bool
     var riskyPortNotificationsEnabled: Bool
+    var quietHoursEnabled: Bool
+    var quietHoursStart: String
+    var quietHoursEnd: String
+    var quietHoursDays: [QuietHoursWeekday]
     var cloudBackupEnabled: Bool
     var cloudBackupFolderPath: String?
     var rooms: [String]
@@ -22,6 +63,10 @@ struct AppSettings: Codable, Equatable, Sendable {
         scheduledScanningEnabled: false,
         newDeviceNotificationsEnabled: true,
         riskyPortNotificationsEnabled: true,
+        quietHoursEnabled: false,
+        quietHoursStart: "22:00",
+        quietHoursEnd: "07:00",
+        quietHoursDays: QuietHoursWeekday.allCases,
         cloudBackupEnabled: false,
         cloudBackupFolderPath: nil,
         rooms: [],
@@ -40,6 +85,10 @@ struct AppSettings: Codable, Equatable, Sendable {
             scheduledScanningEnabled: scheduledScanningEnabled,
             newDeviceNotificationsEnabled: newDeviceNotificationsEnabled,
             riskyPortNotificationsEnabled: riskyPortNotificationsEnabled,
+            quietHoursEnabled: quietHoursEnabled,
+            quietHoursStart: Self.normalizedTime(quietHoursStart, fallback: Self.default.quietHoursStart),
+            quietHoursEnd: Self.normalizedTime(quietHoursEnd, fallback: Self.default.quietHoursEnd),
+            quietHoursDays: QuietHoursWeekday.allCases.filter { quietHoursDays.contains($0) },
             cloudBackupEnabled: cloudBackupEnabled,
             cloudBackupFolderPath: normalizedBackupPath?.isEmpty == false ? normalizedBackupPath : nil,
             rooms: Self.normalizedRooms(rooms),
@@ -74,6 +123,10 @@ struct AppSettings: Codable, Equatable, Sendable {
         case scheduledScanningEnabled
         case newDeviceNotificationsEnabled
         case riskyPortNotificationsEnabled
+        case quietHoursEnabled
+        case quietHoursStart
+        case quietHoursEnd
+        case quietHoursDays
         case cloudBackupEnabled
         case cloudBackupFolderPath
         case rooms
@@ -88,6 +141,10 @@ struct AppSettings: Codable, Equatable, Sendable {
         scheduledScanningEnabled: Bool,
         newDeviceNotificationsEnabled: Bool = Self.default.newDeviceNotificationsEnabled,
         riskyPortNotificationsEnabled: Bool = Self.default.riskyPortNotificationsEnabled,
+        quietHoursEnabled: Bool = Self.default.quietHoursEnabled,
+        quietHoursStart: String = Self.default.quietHoursStart,
+        quietHoursEnd: String = Self.default.quietHoursEnd,
+        quietHoursDays: [QuietHoursWeekday] = Self.default.quietHoursDays,
         cloudBackupEnabled: Bool = Self.default.cloudBackupEnabled,
         cloudBackupFolderPath: String? = Self.default.cloudBackupFolderPath,
         rooms: [String] = Self.default.rooms,
@@ -100,6 +157,10 @@ struct AppSettings: Codable, Equatable, Sendable {
         self.scheduledScanningEnabled = scheduledScanningEnabled
         self.newDeviceNotificationsEnabled = newDeviceNotificationsEnabled
         self.riskyPortNotificationsEnabled = riskyPortNotificationsEnabled
+        self.quietHoursEnabled = quietHoursEnabled
+        self.quietHoursStart = quietHoursStart
+        self.quietHoursEnd = quietHoursEnd
+        self.quietHoursDays = quietHoursDays
         self.cloudBackupEnabled = cloudBackupEnabled
         self.cloudBackupFolderPath = cloudBackupFolderPath
         self.rooms = rooms
@@ -115,6 +176,10 @@ struct AppSettings: Codable, Equatable, Sendable {
         scheduledScanningEnabled = try container.decodeIfPresent(Bool.self, forKey: .scheduledScanningEnabled) ?? Self.default.scheduledScanningEnabled
         newDeviceNotificationsEnabled = try container.decodeIfPresent(Bool.self, forKey: .newDeviceNotificationsEnabled) ?? Self.default.newDeviceNotificationsEnabled
         riskyPortNotificationsEnabled = try container.decodeIfPresent(Bool.self, forKey: .riskyPortNotificationsEnabled) ?? Self.default.riskyPortNotificationsEnabled
+        quietHoursEnabled = try container.decodeIfPresent(Bool.self, forKey: .quietHoursEnabled) ?? Self.default.quietHoursEnabled
+        quietHoursStart = try container.decodeIfPresent(String.self, forKey: .quietHoursStart) ?? Self.default.quietHoursStart
+        quietHoursEnd = try container.decodeIfPresent(String.self, forKey: .quietHoursEnd) ?? Self.default.quietHoursEnd
+        quietHoursDays = try container.decodeIfPresent([QuietHoursWeekday].self, forKey: .quietHoursDays) ?? Self.default.quietHoursDays
         cloudBackupEnabled = try container.decodeIfPresent(Bool.self, forKey: .cloudBackupEnabled) ?? Self.default.cloudBackupEnabled
         cloudBackupFolderPath = try container.decodeIfPresent(String.self, forKey: .cloudBackupFolderPath) ?? Self.default.cloudBackupFolderPath
         rooms = try container.decodeIfPresent([String].self, forKey: .rooms) ?? Self.default.rooms
@@ -131,5 +196,51 @@ struct AppSettings: Codable, Equatable, Sendable {
         return Array(Set(trimmed.filter { !$0.isEmpty })).sorted {
             $0.localizedStandardCompare($1) == .orderedAscending
         }
+    }
+
+    func quietHoursActive(at date: Date = .now, calendar: Calendar = .current) -> Bool {
+        guard quietHoursEnabled,
+              !quietHoursDays.isEmpty,
+              let startMinutes = Self.timeMinutes(quietHoursStart),
+              let endMinutes = Self.timeMinutes(quietHoursEnd) else {
+            return false
+        }
+
+        let components = calendar.dateComponents([.hour, .minute], from: date)
+        guard let hour = components.hour, let minute = components.minute else { return false }
+        let currentMinutes = hour * 60 + minute
+
+        var weekdayDate = date
+        if startMinutes > endMinutes, currentMinutes < endMinutes {
+            weekdayDate = calendar.date(byAdding: .day, value: -1, to: date) ?? date
+        }
+        guard let weekday = QuietHoursWeekday.from(
+            calendarWeekday: calendar.component(.weekday, from: weekdayDate)
+        ), quietHoursDays.contains(weekday) else {
+            return false
+        }
+
+        if startMinutes == endMinutes { return true }
+        if startMinutes < endMinutes {
+            return currentMinutes >= startMinutes && currentMinutes < endMinutes
+        }
+        return currentMinutes >= startMinutes || currentMinutes < endMinutes
+    }
+
+    private static func normalizedTime(_ value: String, fallback: String) -> String {
+        guard let minutes = timeMinutes(value) else { return fallback }
+        return String(format: "%02d:%02d", minutes / 60, minutes % 60)
+    }
+
+    private static func timeMinutes(_ value: String) -> Int? {
+        let parts = value.split(separator: ":", omittingEmptySubsequences: false)
+        guard parts.count == 2,
+              let hour = Int(parts[0]),
+              let minute = Int(parts[1]),
+              (0...23).contains(hour),
+              (0...59).contains(minute) else {
+            return nil
+        }
+        return hour * 60 + minute
     }
 }

--- a/macos/LanGuardMac/Sources/LanGuardMac/Models/NetworkDevice.swift
+++ b/macos/LanGuardMac/Sources/LanGuardMac/Models/NetworkDevice.swift
@@ -1,12 +1,64 @@
 import Foundation
 
+enum DeviceIdentitySource: String, Codable, Hashable, Sendable {
+    case reverseDNS = "reverse_dns"
+    case mdns
+    case llmnr
+    case netBIOS = "netbios"
+    case ssdp
+    case snmp
+    case http
+    case arp
+    case manuf
+    case inferred
+    case imported
+
+    var title: String {
+        switch self {
+        case .reverseDNS: "Reverse DNS"
+        case .mdns: "mDNS"
+        case .llmnr: "LLMNR"
+        case .netBIOS: "NetBIOS"
+        case .ssdp: "SSDP / UPnP"
+        case .snmp: "SNMP"
+        case .http: "Device web interface"
+        case .arp: "ARP"
+        case .manuf: "Wireshark manuf"
+        case .inferred: "Inferred"
+        case .imported: "Imported inventory"
+        }
+    }
+
+    var confidence: DeviceIdentityConfidence {
+        switch self {
+        case .reverseDNS, .mdns, .llmnr, .netBIOS, .snmp, .manuf:
+            .high
+        case .ssdp, .http, .arp, .imported:
+            .medium
+        case .inferred:
+            .low
+        }
+    }
+}
+
+enum DeviceIdentityConfidence: String, Codable, Hashable, Sendable {
+    case none
+    case low
+    case medium
+    case high
+
+    var title: String { rawValue.capitalized }
+}
+
 struct NetworkDevice: Codable, Identifiable, Hashable, Sendable {
     let id: String
     var name: String
     var ipAddress: String
     var macAddress: String
     var vendor: String?
+    var vendorSource: DeviceIdentitySource?
     var hostname: String?
+    var hostnameSource: DeviceIdentitySource?
     var comments: String
     var externalURL: String?
     var attentionAcknowledgedRiskSignature: String?
@@ -29,7 +81,9 @@ struct NetworkDevice: Codable, Identifiable, Hashable, Sendable {
         ipAddress: String,
         macAddress: String,
         vendor: String? = nil,
+        vendorSource: DeviceIdentitySource? = nil,
         hostname: String? = nil,
+        hostnameSource: DeviceIdentitySource? = nil,
         comments: String = "",
         externalURL: String? = nil,
         attentionAcknowledgedRiskSignature: String? = nil,
@@ -51,7 +105,9 @@ struct NetworkDevice: Codable, Identifiable, Hashable, Sendable {
         self.ipAddress = ipAddress
         self.macAddress = macAddress
         self.vendor = vendor
+        self.vendorSource = vendor == nil ? nil : vendorSource
         self.hostname = HostnameResolver.clean(hostname, ipAddress: ipAddress)
+        self.hostnameSource = self.hostname == nil ? nil : hostnameSource
         self.comments = comments
         self.externalURL = ExternalLinkValidator.normalizedString(externalURL)
         self.attentionAcknowledgedRiskSignature = attentionAcknowledgedRiskSignature
@@ -75,7 +131,9 @@ struct NetworkDevice: Codable, Identifiable, Hashable, Sendable {
         case ipAddress
         case macAddress
         case vendor
+        case vendorSource
         case hostname
+        case hostnameSource
         case comments
         case externalURL
         case attentionAcknowledgedRiskSignature
@@ -100,8 +158,12 @@ struct NetworkDevice: Codable, Identifiable, Hashable, Sendable {
         ipAddress = try container.decode(String.self, forKey: .ipAddress)
         macAddress = try container.decode(String.self, forKey: .macAddress)
         vendor = try container.decodeIfPresent(String.self, forKey: .vendor)
+        vendorSource = try container.decodeIfPresent(DeviceIdentitySource.self, forKey: .vendorSource)
         let decodedHostname = try container.decodeIfPresent(String.self, forKey: .hostname)
         hostname = HostnameResolver.clean(decodedHostname, ipAddress: ipAddress)
+        hostnameSource = try container.decodeIfPresent(DeviceIdentitySource.self, forKey: .hostnameSource)
+        if vendor == nil { vendorSource = nil }
+        if hostname == nil { hostnameSource = nil }
         comments = try container.decodeIfPresent(String.self, forKey: .comments) ?? ""
         externalURL = ExternalLinkValidator.normalizedString(
             try container.decodeIfPresent(String.self, forKey: .externalURL)
@@ -126,6 +188,27 @@ struct NetworkDevice: Codable, Identifiable, Hashable, Sendable {
 }
 
 extension NetworkDevice {
+    var hostnameConfidence: DeviceIdentityConfidence {
+        guard hostname != nil else { return .none }
+        return hostnameSource?.confidence ?? .low
+    }
+
+    var vendorConfidence: DeviceIdentityConfidence {
+        guard vendor != nil else { return .none }
+        return vendorSource?.confidence ?? .low
+    }
+
+    var identityConfidence: DeviceIdentityConfidence {
+        if hostnameConfidence == .high, vendorConfidence == .high {
+            return .high
+        }
+        if hostnameConfidence == .high || vendorConfidence == .high
+            || (hostnameConfidence == .medium && vendorConfidence == .medium) {
+            return .medium
+        }
+        return .low
+    }
+
     var riskFingerprint: String {
         [
             isKnown ? "known" : "unknown",
@@ -149,6 +232,7 @@ extension NetworkDevice {
 
     static func discovered(
         hostname: String?,
+        hostnameSource: DeviceIdentitySource? = nil,
         ipAddress: String,
         macAddress: String,
         gatewayAddress: String?,
@@ -163,6 +247,7 @@ extension NetworkDevice {
             ipAddress: ipAddress,
             macAddress: normalizedMAC,
             hostname: hostname,
+            hostnameSource: hostnameSource,
             status: .online,
             risk: .low,
             isKnown: false,

--- a/macos/LanGuardMac/Sources/LanGuardMac/Services/ARPEntry.swift
+++ b/macos/LanGuardMac/Sources/LanGuardMac/Services/ARPEntry.swift
@@ -2,6 +2,19 @@ import Foundation
 
 struct ARPEntry: Equatable, Sendable {
     var hostname: String?
+    var hostnameSource: DeviceIdentitySource?
     var ipAddress: String
     var macAddress: String
+
+    init(
+        hostname: String?,
+        hostnameSource: DeviceIdentitySource? = nil,
+        ipAddress: String,
+        macAddress: String
+    ) {
+        self.hostname = hostname
+        self.hostnameSource = hostname == nil ? nil : hostnameSource
+        self.ipAddress = ipAddress
+        self.macAddress = macAddress
+    }
 }

--- a/macos/LanGuardMac/Sources/LanGuardMac/Services/ARPTableParser.swift
+++ b/macos/LanGuardMac/Sources/LanGuardMac/Services/ARPTableParser.swift
@@ -36,6 +36,7 @@ enum ARPTableParser {
 
         return ARPEntry(
             hostname: hostname,
+            hostnameSource: hostname == nil ? nil : .arp,
             ipAddress: ipAddress,
             macAddress: macAddress
         )

--- a/macos/LanGuardMac/Sources/LanGuardMac/Services/DeviceInventoryTransfer.swift
+++ b/macos/LanGuardMac/Sources/LanGuardMac/Services/DeviceInventoryTransfer.swift
@@ -39,7 +39,9 @@ struct DeviceInventoryItem: Codable {
     var ip: String
     var mac: String
     var vendor: String?
+    var vendorSource: String?
     var hostname: String?
+    var hostnameSource: String?
     var comments: String?
     var externalURL: String?
     var attentionAcknowledged: Bool?
@@ -60,7 +62,9 @@ struct DeviceInventoryItem: Codable {
         self.ip = device.ipAddress
         self.mac = device.macAddress
         self.vendor = device.vendor
+        self.vendorSource = device.vendorSource?.rawValue
         self.hostname = device.hostname
+        self.hostnameSource = device.hostnameSource?.rawValue
         self.comments = device.comments
         self.externalURL = device.externalURL
         self.attentionAcknowledged = device.isAttentionAcknowledged
@@ -106,6 +110,10 @@ struct DeviceInventoryItem: Codable {
         let importedName = displayName.isEmpty ? fallbackName : displayName
         let importedVendor = normalizedText(vendor) ?? existing?.vendor
         let importedHostname = normalizedText(hostname) ?? existing?.hostname
+        let importedVendorSource = DeviceIdentitySource(rawValue: vendorSource ?? "")
+            ?? (importedVendor == nil ? nil : existing?.vendorSource ?? .imported)
+        let importedHostnameSource = DeviceIdentitySource(rawValue: hostnameSource ?? "")
+            ?? (importedHostname == nil ? nil : existing?.hostnameSource ?? .imported)
         let importedComments = comments ?? existing?.comments ?? ""
         let importedExternalURL = ExternalLinkValidator.normalizedString(externalURL) ?? existing?.externalURL
         let importedIcon = normalizedText(icon) ?? existing?.iconName
@@ -119,7 +127,9 @@ struct DeviceInventoryItem: Codable {
             ipAddress: normalizedIP,
             macAddress: normalizedMAC,
             vendor: importedVendor,
+            vendorSource: importedVendorSource,
             hostname: importedHostname,
+            hostnameSource: importedHostnameSource,
             comments: importedComments,
             externalURL: importedExternalURL,
             iconName: importedIcon,
@@ -166,7 +176,9 @@ struct DeviceInventoryItem: Codable {
         case ip
         case mac
         case vendor
+        case vendorSource = "vendor_source"
         case hostname
+        case hostnameSource = "hostname_source"
         case comments
         case externalURL = "external_url"
         case attentionAcknowledged = "attention_acknowledged"

--- a/macos/LanGuardMac/Sources/LanGuardMac/Services/DeviceMerger.swift
+++ b/macos/LanGuardMac/Sources/LanGuardMac/Services/DeviceMerger.swift
@@ -47,7 +47,9 @@ enum DeviceMerger {
                 merged.secondaryIconName = device.secondaryIconName
             }
             merged.hostname = HostnameResolver.clean(device.hostname)
+            merged.hostnameSource = merged.hostname == nil ? nil : device.hostnameSource
             merged.vendor = MACVendorResolver.displayVendor(device.vendor)
+            merged.vendorSource = merged.vendor == nil ? nil : device.vendorSource
             merged.comments = previous.comments
             merged.externalURL = previous.externalURL
             merged.attentionAcknowledgedRiskSignature = previous.attentionAcknowledgedRiskSignature
@@ -107,7 +109,9 @@ enum DeviceMerger {
             current.ipAddress = latest.ipAddress
             current.macAddress = latest.macAddress
             current.vendor = latest.vendor ?? current.vendor
+            if latest.vendor != nil { current.vendorSource = latest.vendorSource }
             current.hostname = preferredHostname(latest.hostname, fallback: current.hostname)
+            if latest.hostname != nil { current.hostnameSource = latest.hostnameSource }
             current.comments = latest.comments.isEmpty ? current.comments : latest.comments
             current.externalURL = latest.externalURL ?? current.externalURL
             current.attentionAcknowledgedRiskSignature = (

--- a/macos/LanGuardMac/Sources/LanGuardMac/Services/DeviceMetadataProbe.swift
+++ b/macos/LanGuardMac/Sources/LanGuardMac/Services/DeviceMetadataProbe.swift
@@ -2,11 +2,20 @@ import Foundation
 
 struct DeviceMetadata: Equatable, Sendable {
     var vendor: String?
+    var vendorSource: DeviceIdentitySource?
     var hostname: String?
+    var hostnameSource: DeviceIdentitySource?
 
-    init(vendor: String? = nil, hostname: String? = nil) {
+    init(
+        vendor: String? = nil,
+        vendorSource: DeviceIdentitySource? = nil,
+        hostname: String? = nil,
+        hostnameSource: DeviceIdentitySource? = nil
+    ) {
         self.vendor = vendor
+        self.vendorSource = vendor == nil ? nil : vendorSource
         self.hostname = HostnameResolver.clean(hostname)
+        self.hostnameSource = self.hostname == nil ? nil : hostnameSource
     }
 }
 
@@ -107,7 +116,9 @@ struct HTTPDeviceMetadataProbe: DeviceMetadataProbing {
 
         return DeviceMetadata(
             vendor: vendor,
-            hostname: hostname
+            vendorSource: vendor == nil ? nil : .http,
+            hostname: hostname,
+            hostnameSource: hostname == nil ? nil : .http
         )
     }
 

--- a/macos/LanGuardMac/Sources/LanGuardMac/Services/DeviceProfiler.swift
+++ b/macos/LanGuardMac/Sources/LanGuardMac/Services/DeviceProfiler.swift
@@ -24,6 +24,13 @@ enum DeviceProfiler {
 
         var enriched = device
         enriched.vendor = vendor
+        if vendor == nil {
+            enriched.vendorSource = nil
+        } else if resolvedVendor != device.vendor {
+            enriched.vendorSource = .manuf
+        } else if resolvedVendor == nil {
+            enriched.vendorSource = .inferred
+        }
         enriched.iconName = iconName
         enriched.name = name
         return enriched

--- a/macos/LanGuardMac/Sources/LanGuardMac/Services/NetworkMetadataDiscovery.swift
+++ b/macos/LanGuardMac/Sources/LanGuardMac/Services/NetworkMetadataDiscovery.swift
@@ -107,7 +107,10 @@ struct DNSPTRMetadataDiscovery: NetworkMetadataDiscovering {
                         guard let hostname = await resolveHostname(ipAddress: ipAddress, timeoutSeconds: timeoutSeconds) else {
                             return nil
                         }
-                        return (ipAddress, DeviceMetadata(vendor: nil, hostname: hostname))
+                        return (ipAddress, DeviceMetadata(
+                            hostname: hostname,
+                            hostnameSource: .reverseDNS
+                        ))
                     }
                 }
 
@@ -200,7 +203,9 @@ struct SNMPMetadataDiscovery: NetworkMetadataDiscovering {
     static func metadata(sysName: String?, sysDescr: String?, ipAddress: String = "") -> DeviceMetadata {
         DeviceMetadata(
             vendor: cleanedSNMPValue(sysDescr),
-            hostname: HostnameResolver.clean(cleanedSNMPValue(sysName), ipAddress: ipAddress)
+            vendorSource: cleanedSNMPValue(sysDescr) == nil ? nil : .snmp,
+            hostname: HostnameResolver.clean(cleanedSNMPValue(sysName), ipAddress: ipAddress),
+            hostnameSource: cleanedSNMPValue(sysName) == nil ? nil : .snmp
         )
     }
 
@@ -298,7 +303,7 @@ struct SSDPMetadataDiscovery: NetworkMetadataDiscovering {
         let serverVendor = explicitVendor(fromServerHeader: response.headers["server"])
         var metadata = DeviceMetadata(
             vendor: MACVendorResolver.displayVendor(serverVendor),
-            hostname: nil
+            vendorSource: serverVendor == nil ? nil : .ssdp
         )
 
         if let location = response.headers["location"],
@@ -318,7 +323,9 @@ struct SSDPMetadataDiscovery: NetworkMetadataDiscovering {
 
         return DeviceMetadata(
             vendor: MACVendorResolver.displayVendor(manufacturer),
-            hostname: hostname
+            vendorSource: manufacturer == nil ? nil : .ssdp,
+            hostname: hostname,
+            hostnameSource: hostname == nil ? nil : .ssdp
         )
     }
 
@@ -400,7 +407,10 @@ struct MDNSReverseMetadataDiscovery: NetworkMetadataDiscovering {
                         guard let hostname = await resolveHostname(ipAddress: ipAddress, timeout: timeout) else {
                             return nil
                         }
-                        return (ipAddress, DeviceMetadata(vendor: nil, hostname: hostname))
+                        return (ipAddress, DeviceMetadata(
+                            hostname: hostname,
+                            hostnameSource: .mdns
+                        ))
                     }
                 }
 
@@ -517,7 +527,8 @@ struct MDNSPTRSocketDiscovery: NetworkMetadataDiscovering {
             port: 5353,
             timeout: timeout,
             concurrency: concurrency,
-            transactionID: 0
+            transactionID: 0,
+            source: .mdns
         )
         .discoverMetadata(for: ipAddresses)
     }
@@ -542,7 +553,8 @@ struct LLMNRReverseMetadataDiscovery: NetworkMetadataDiscovering {
             port: 5355,
             timeout: timeout,
             concurrency: concurrency,
-            transactionID: 0x4c47
+            transactionID: 0x4c47,
+            source: .llmnr
         )
         .discoverMetadata(for: ipAddresses)
     }
@@ -592,7 +604,10 @@ struct MDNSServiceMetadataDiscovery: NetworkMetadataDiscovering {
 
         var metadataByIP: [String: DeviceMetadata] = [:]
         for (ipAddress, hostname) in hostnamesByIP where allowedIPs.contains(ipAddress) {
-            metadataByIP[ipAddress] = DeviceMetadata(vendor: nil, hostname: hostname)
+            metadataByIP[ipAddress] = DeviceMetadata(
+                hostname: hostname,
+                hostnameSource: .mdns
+            )
         }
         return metadataByIP
     }
@@ -731,6 +746,7 @@ private struct ReversePTRSocketDiscovery: NetworkMetadataDiscovering {
     let timeout: TimeInterval
     let concurrency: Int
     let transactionID: UInt16
+    let source: DeviceIdentitySource
 
     func discoverMetadata(for ipAddresses: [String]) async -> [String: DeviceMetadata] {
         var metadataByIP: [String: DeviceMetadata] = [:]
@@ -746,7 +762,10 @@ private struct ReversePTRSocketDiscovery: NetworkMetadataDiscovering {
                         guard let hostname = await resolveHostname(ipAddress: ipAddress) else {
                             return nil
                         }
-                        return (ipAddress, DeviceMetadata(vendor: nil, hostname: hostname))
+                        return (ipAddress, DeviceMetadata(
+                            hostname: hostname,
+                            hostnameSource: source
+                        ))
                     }
                 }
 
@@ -848,7 +867,10 @@ struct NetBIOSNameDiscovery: NetworkMetadataDiscovering {
                         guard let hostname = await resolveHostname(ipAddress: ipAddress, timeout: timeout) else {
                             return nil
                         }
-                        return (ipAddress, DeviceMetadata(vendor: nil, hostname: hostname))
+                        return (ipAddress, DeviceMetadata(
+                            hostname: hostname,
+                            hostnameSource: .netBIOS
+                        ))
                     }
                 }
 
@@ -1482,7 +1504,9 @@ private extension DeviceMetadata {
     func merged(with other: DeviceMetadata) -> DeviceMetadata {
         DeviceMetadata(
             vendor: other.vendor ?? vendor,
-            hostname: other.hostname ?? hostname
+            vendorSource: other.vendor == nil ? vendorSource : other.vendorSource,
+            hostname: other.hostname ?? hostname,
+            hostnameSource: other.hostname == nil ? hostnameSource : other.hostnameSource
         )
     }
 }

--- a/macos/LanGuardMac/Sources/LanGuardMac/Services/NetworkScanner.swift
+++ b/macos/LanGuardMac/Sources/LanGuardMac/Services/NetworkScanner.swift
@@ -59,6 +59,7 @@ struct LocalNetworkScanner: NetworkScanning {
                     var resolvedEntry = entry
                     if resolvedEntry.hostname?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty != false {
                         resolvedEntry.hostname = HostnameResolver.resolve(ipAddress: entry.ipAddress)
+                        resolvedEntry.hostnameSource = resolvedEntry.hostname == nil ? nil : .reverseDNS
                     }
                     return resolvedEntry
                 }
@@ -74,6 +75,7 @@ struct LocalNetworkScanner: NetworkScanning {
         let devices = entries.map { entry in
             NetworkDevice.discovered(
                 hostname: entry.hostname,
+                hostnameSource: entry.hostnameSource,
                 ipAddress: entry.ipAddress,
                 macAddress: entry.macAddress,
                 gatewayAddress: gatewayAddress,
@@ -87,10 +89,18 @@ struct LocalNetworkScanner: NetworkScanning {
                     var scannedDevice = device
                     let networkMetadata = discoveredMetadata[device.ipAddress]
                     scannedDevice.vendor = networkMetadata?.vendor ?? scannedDevice.vendor
+                    scannedDevice.vendorSource = networkMetadata?.vendor == nil
+                        ? scannedDevice.vendorSource
+                        : networkMetadata?.vendorSource
+                    let shouldUseNetworkHostname = HostnameResolver.clean(scannedDevice.hostname) == nil
+                        && HostnameResolver.clean(networkMetadata?.hostname) != nil
                     scannedDevice.hostname = preferredHostname(
                         current: scannedDevice.hostname,
                         candidate: networkMetadata?.hostname
                     )
+                    if shouldUseNetworkHostname {
+                        scannedDevice.hostnameSource = networkMetadata?.hostnameSource
+                    }
                     scannedDevice.openPorts = await portScanner.scanOpenPorts(
                         host: device.ipAddress,
                         ports: settings.tcpPorts
@@ -100,10 +110,18 @@ struct LocalNetworkScanner: NetworkScanning {
                         openPorts: scannedDevice.openPorts
                     )
                     scannedDevice.vendor = metadata.vendor ?? scannedDevice.vendor
+                    if metadata.vendor != nil {
+                        scannedDevice.vendorSource = metadata.vendorSource
+                    }
+                    let shouldUseHTTPHostname = HostnameResolver.clean(scannedDevice.hostname) == nil
+                        && HostnameResolver.clean(metadata.hostname) != nil
                     scannedDevice.hostname = preferredHostname(
                         current: scannedDevice.hostname,
                         candidate: metadata.hostname
                     )
+                    if shouldUseHTTPHostname {
+                        scannedDevice.hostnameSource = metadata.hostnameSource
+                    }
                     scannedDevice.risk = DeviceRiskScorer.risk(
                         for: scannedDevice.openPorts,
                         isKnown: scannedDevice.isKnown,

--- a/macos/LanGuardMac/Sources/LanGuardMac/SettingsView.swift
+++ b/macos/LanGuardMac/Sources/LanGuardMac/SettingsView.swift
@@ -12,6 +12,10 @@ struct SettingsView: View {
     @State private var scheduledScanningEnabled = AppSettings.default.scheduledScanningEnabled
     @State private var newDeviceNotificationsEnabled = AppSettings.default.newDeviceNotificationsEnabled
     @State private var riskyPortNotificationsEnabled = AppSettings.default.riskyPortNotificationsEnabled
+    @State private var quietHoursEnabled = AppSettings.default.quietHoursEnabled
+    @State private var quietHoursStart = Self.date(for: AppSettings.default.quietHoursStart)
+    @State private var quietHoursEnd = Self.date(for: AppSettings.default.quietHoursEnd)
+    @State private var quietHoursDays = AppSettings.default.quietHoursDays
     @State private var cloudBackupEnabled = AppSettings.default.cloudBackupEnabled
     @State private var cloudBackupFolderPath = AppSettings.default.cloudBackupFolderPath ?? ""
     @State private var launchAtLoginEnabled = LaunchAtLoginService.isEnabled
@@ -97,6 +101,33 @@ struct SettingsView: View {
                 Section("Notifications") {
                     Toggle("New unknown devices", isOn: $newDeviceNotificationsEnabled)
                     Toggle("High-risk open ports", isOn: $riskyPortNotificationsEnabled)
+                    Toggle("Quiet hours", isOn: $quietHoursEnabled)
+
+                    HStack {
+                        DatePicker(
+                            "From",
+                            selection: $quietHoursStart,
+                            displayedComponents: .hourAndMinute
+                        )
+                        DatePicker(
+                            "Until",
+                            selection: $quietHoursEnd,
+                            displayedComponents: .hourAndMinute
+                        )
+                    }
+                    .disabled(!quietHoursEnabled)
+
+                    HStack(spacing: 12) {
+                        ForEach(QuietHoursWeekday.allCases) { day in
+                            Toggle(day.shortTitle, isOn: quietHoursBinding(for: day))
+                                .toggleStyle(.checkbox)
+                        }
+                    }
+                    .disabled(!quietHoursEnabled)
+
+                    Text("For overnight ranges, early morning hours belong to the previous day.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
 
                     Button {
                         sendTestNotification()
@@ -258,6 +289,10 @@ struct SettingsView: View {
             scheduledScanningEnabled: scheduledScanningEnabled,
             newDeviceNotificationsEnabled: newDeviceNotificationsEnabled,
             riskyPortNotificationsEnabled: riskyPortNotificationsEnabled,
+            quietHoursEnabled: quietHoursEnabled,
+            quietHoursStart: Self.timeString(from: quietHoursStart),
+            quietHoursEnd: Self.timeString(from: quietHoursEnd),
+            quietHoursDays: quietHoursDays,
             cloudBackupEnabled: cloudBackupEnabled,
             cloudBackupFolderPath: backupPath.isEmpty ? nil : backupPath,
             rooms: rooms
@@ -282,8 +317,43 @@ struct SettingsView: View {
         scheduledScanningEnabled = settings.scheduledScanningEnabled
         newDeviceNotificationsEnabled = settings.newDeviceNotificationsEnabled
         riskyPortNotificationsEnabled = settings.riskyPortNotificationsEnabled
+        quietHoursEnabled = settings.quietHoursEnabled
+        quietHoursStart = Self.date(for: settings.quietHoursStart)
+        quietHoursEnd = Self.date(for: settings.quietHoursEnd)
+        quietHoursDays = settings.quietHoursDays
         cloudBackupEnabled = settings.cloudBackupEnabled
         cloudBackupFolderPath = settings.cloudBackupFolderPath ?? ""
+    }
+
+    private func quietHoursBinding(for day: QuietHoursWeekday) -> Binding<Bool> {
+        Binding(
+            get: { quietHoursDays.contains(day) },
+            set: { selected in
+                if selected {
+                    if !quietHoursDays.contains(day) {
+                        quietHoursDays.append(day)
+                    }
+                } else {
+                    quietHoursDays.removeAll { $0 == day }
+                }
+                quietHoursDays = QuietHoursWeekday.allCases.filter { quietHoursDays.contains($0) }
+            }
+        )
+    }
+
+    private static func date(for time: String) -> Date {
+        let parts = time.split(separator: ":")
+        guard parts.count == 2,
+              let hour = Int(parts[0]),
+              let minute = Int(parts[1]) else {
+            return .now
+        }
+        return Calendar.current.date(bySettingHour: hour, minute: minute, second: 0, of: .now) ?? .now
+    }
+
+    private static func timeString(from date: Date) -> String {
+        let components = Calendar.current.dateComponents([.hour, .minute], from: date)
+        return String(format: "%02d:%02d", components.hour ?? 0, components.minute ?? 0)
     }
 
     private func addRoom() {

--- a/macos/LanGuardMac/Sources/LanGuardMac/ViewModels/AppModel.swift
+++ b/macos/LanGuardMac/Sources/LanGuardMac/ViewModels/AppModel.swift
@@ -364,6 +364,8 @@ final class AppModel {
     }
 
     private func notifyScanChanges(_ mergeResult: DeviceMergeResult) async {
+        guard !settings.quietHoursActive() else { return }
+
         if settings.newDeviceNotificationsEnabled {
             for device in mergeResult.newDevices where !device.isKnown {
                 await notifications.notifyNewDevice(device)
@@ -378,6 +380,8 @@ final class AppModel {
     }
 
     private func notifyNewDevices(_ devices: [NetworkDevice]) async {
+        guard !settings.quietHoursActive() else { return }
+
         for device in devices where !device.isKnown {
             await notifications.notifyNewDevice(device)
         }

--- a/macos/LanGuardMac/Tests/LanGuardMacTests/AppSettingsTests.swift
+++ b/macos/LanGuardMac/Tests/LanGuardMacTests/AppSettingsTests.swift
@@ -1,4 +1,5 @@
 import Testing
+import Foundation
 @testable import LanGuardMac
 
 @Test
@@ -33,4 +34,58 @@ func cidrRangeRejectsNetworkAndBroadcastAsUsableHosts() {
     #expect(range?.isUsableHost("192.168.0.1") == true)
     #expect(range?.isUsableHost("192.168.0.0") == false)
     #expect(range?.isUsableHost("192.168.0.255") == false)
+}
+
+@Test
+func appSettingsQuietHoursApplyOnlyOnSelectedDay() {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+    let monday = calendar.date(from: DateComponents(year: 2026, month: 8, day: 24, hour: 12))!
+    let tuesday = calendar.date(from: DateComponents(year: 2026, month: 8, day: 25, hour: 12))!
+    let settings = AppSettings(
+        defaultScanRange: "192.168.0.0/24",
+        scanIntervalMinutes: 5,
+        tcpPorts: AppSettings.defaultPorts,
+        scheduledScanningEnabled: false,
+        quietHoursEnabled: true,
+        quietHoursStart: "09:00",
+        quietHoursEnd: "17:00",
+        quietHoursDays: [.monday]
+    )
+
+    #expect(settings.quietHoursActive(at: monday, calendar: calendar))
+    #expect(!settings.quietHoursActive(at: tuesday, calendar: calendar))
+}
+
+@Test
+func appSettingsOvernightQuietHoursUseStartingDay() {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+    let mondayNight = calendar.date(from: DateComponents(year: 2026, month: 8, day: 24, hour: 23))!
+    let tuesdayMorning = calendar.date(from: DateComponents(year: 2026, month: 8, day: 25, hour: 2))!
+    let tuesdayNight = calendar.date(from: DateComponents(year: 2026, month: 8, day: 25, hour: 23))!
+    let settings = AppSettings(
+        defaultScanRange: "192.168.0.0/24",
+        scanIntervalMinutes: 5,
+        tcpPorts: AppSettings.defaultPorts,
+        scheduledScanningEnabled: false,
+        quietHoursEnabled: true,
+        quietHoursStart: "22:00",
+        quietHoursEnd: "07:00",
+        quietHoursDays: [.monday]
+    )
+
+    #expect(settings.quietHoursActive(at: mondayNight, calendar: calendar))
+    #expect(settings.quietHoursActive(at: tuesdayMorning, calendar: calendar))
+    #expect(!settings.quietHoursActive(at: tuesdayNight, calendar: calendar))
+}
+
+@Test
+func appSettingsDecodesLegacyDataWithQuietHoursDefaults() throws {
+    let settings = try JSONDecoder().decode(AppSettings.self, from: Data("{}".utf8))
+
+    #expect(!settings.quietHoursEnabled)
+    #expect(settings.quietHoursStart == "22:00")
+    #expect(settings.quietHoursEnd == "07:00")
+    #expect(settings.quietHoursDays == QuietHoursWeekday.allCases)
 }

--- a/macos/LanGuardMac/Tests/LanGuardMacTests/LanGuardMacTests.swift
+++ b/macos/LanGuardMac/Tests/LanGuardMacTests/LanGuardMacTests.swift
@@ -54,9 +54,43 @@ func arpParserParsesKnownHostLine() {
 
     #expect(entry == ARPEntry(
         hostname: "router",
+        hostnameSource: .arp,
         ipAddress: "192.168.0.1",
         macAddress: "01:02:03:0a:0b:0c"
     ))
+}
+
+@Test
+func deviceIdentityConfidenceUsesCollectedEvidence() {
+    let device = NetworkDevice(
+        id: "90:dd:5d:b7:bd:01",
+        name: "Living room streamer",
+        ipAddress: "192.168.0.20",
+        macAddress: "90:dd:5d:b7:bd:01",
+        vendor: "Apple, Inc.",
+        vendorSource: .manuf,
+        hostname: "living-room-streamer.local",
+        hostnameSource: .mdns
+    )
+
+    #expect(device.identityConfidence == .high)
+    #expect(device.hostnameConfidence == .high)
+    #expect(device.vendorConfidence == .high)
+}
+
+@Test
+func deviceIdentityConfidenceDoesNotOverstateLegacyValues() {
+    let device = NetworkDevice(
+        id: "90:dd:5d:b7:bd:02",
+        name: "Legacy device",
+        ipAddress: "192.168.0.21",
+        macAddress: "90:dd:5d:b7:bd:02",
+        vendor: "Example vendor"
+    )
+
+    #expect(device.identityConfidence == .low)
+    #expect(device.vendorConfidence == .low)
+    #expect(device.hostnameConfidence == .none)
 }
 
 @Test
@@ -154,6 +188,10 @@ func deviceInventoryRoundTripPreservesCommentsAndAttentionAcknowledgement() thro
         name: "Lab server",
         ipAddress: "192.168.1.20",
         macAddress: "aa:bb:cc:dd:ee:ff",
+        vendor: "Example vendor",
+        vendorSource: .manuf,
+        hostname: "lab-server.local",
+        hostnameSource: .mdns,
         comments: "Remote access is expected on this trusted device.",
         externalURL: "https://192.168.1.20:8443",
         risk: .high,
@@ -171,6 +209,8 @@ func deviceInventoryRoundTripPreservesCommentsAndAttentionAcknowledgement() thro
     #expect(imported?.externalURL == "https://192.168.1.20:8443")
     #expect(imported?.isAttentionAcknowledged == true)
     #expect(imported?.needsAttention == false)
+    #expect(imported?.vendorSource == .manuf)
+    #expect(imported?.hostnameSource == .mdns)
 }
 
 @Test

--- a/macos/LanGuardMac/Tests/LanGuardMacTests/NetworkScannerTests.swift
+++ b/macos/LanGuardMac/Tests/LanGuardMacTests/NetworkScannerTests.swift
@@ -65,7 +65,7 @@ private struct HostnameMetadataDiscovery: NetworkMetadataDiscovering {
 
     func discoverMetadata(for ipAddresses: [String]) async -> [String: DeviceMetadata] {
         [
-            ipAddress: DeviceMetadata(hostname: hostname)
+            ipAddress: DeviceMetadata(hostname: hostname, hostnameSource: .mdns)
         ]
     }
 }
@@ -291,4 +291,5 @@ func localScannerUsesNetworkMetadataHostnameWhenCurrentHostnameIsMissing() async
 
     let device = try #require(devices.first { $0.ipAddress == "192.168.0.31" })
     #expect(device.hostname == "HAA 123456")
+    #expect(device.hostnameSource == .mdns)
 }


### PR DESCRIPTION
## Summary

- add device identity confidence and source evidence in Docker and macOS
- add selected weekdays to notification quiet hours in Docker and macOS
- improve responsive device-list sizing and first-seen row presentation
- preserve identity source metadata across inventory export and import
- bump Docker and macOS versions to 1.7.0

## Verification

- backend: 188 tests passed
- backend migrations: no pending changes
- OpenAPI schema validation passed
- frontend lint passed
- frontend production build passed
- macOS: 99 tests passed

Closes #101
Closes #102
Closes #104