### PR TITLE
Add WatchYourLAN inventory migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Added a Docker migration tool for importing the current WatchYourLAN device inventory from its `/api/all` JSON output.
 - Added Docker scan comparison for completed scan runs, including device, port, and duration differences.
 - Improved Docker gateway presentation while preserving user-selected device roles across scans.
 - Improved Docker router hostname and vendor discovery through gateway DNS and SSDP device metadata.

--- a/README.md
+++ b/README.md
@@ -146,6 +146,37 @@ After sign in, open Settings to change the scan range, scan interval, timezone, 
 
 The scanner waits for the configured scan interval after a scan completes before starting the next scheduled scan. For example, with a 5 minute interval, a scan that finishes at 20:14 will schedule the next scan for about 20:19.
 
+## Migrate from WatchYourLAN
+
+LanGuard can import the current device inventory from
+[WatchYourLAN](https://github.com/aceberg/WatchYourLAN). On the machine that can
+reach WatchYourLAN, download the JSON returned by its documented `/api/all`
+endpoint:
+
+```bash
+curl http://WATCHYOURLAN_IP:8840/api/all -o watchyourlan-devices.json
+```
+
+If WatchYourLAN is published through a reverse proxy, replace the URL with its
+actual address and include the authentication options required by that proxy.
+
+Then:
+
+1. Sign in to LanGuard as an administrator.
+2. Open **Settings**.
+3. Under **WatchYourLAN migration**, select **Import from WatchYourLAN**.
+4. Choose `watchyourlan-devices.json`.
+
+LanGuard matches existing devices by MAC address and imports the device name,
+DNS hostname, IP address, MAC address, hardware vendor, known state, online state,
+and last-seen value. Invalid records are skipped and the completion notification
+shows how many devices were created, updated, or skipped.
+
+WatchYourLAN does not provide LanGuard rooms, roles, icons, comments, open-port
+history, identity confidence, or Home Map layout through this endpoint. Configure
+those fields in LanGuard after the migration; later scans can enrich hostname,
+vendor, port, and status information. Scan history is intentionally not imported.
+
 If you override `DISCORD_ICON_URL`, use a versioned URL when replacing the icon so Discord mobile clients do not reuse an old cached image, for example:
 
 ```env

--- a/backend/core/tests.py
+++ b/backend/core/tests.py
@@ -2889,6 +2889,118 @@ class ScanApiTests(TestCase):
             [80, 443],
         )
 
+    def test_watchyourlan_inventory_import_maps_api_all_hosts(self):
+        response = self.client.post(
+            "/api/v1/devices/import/watchyourlan/",
+            [
+                {
+                    "ID": 7,
+                    "Name": "Living Room TV",
+                    "DNS": "living-room-tv.local",
+                    "Iface": "eth0",
+                    "IP": "192.168.1.50",
+                    "Mac": "b0:be:76:12:34:56",
+                    "Hw": "TP-Link Systems Inc.",
+                    "Date": "2026-08-29 10:30:00",
+                    "Known": 1,
+                    "Now": 1,
+                },
+                {
+                    "ID": 8,
+                    "Name": "Offline tablet",
+                    "DNS": "",
+                    "Iface": "eth0",
+                    "IP": "192.168.1.51",
+                    "Mac": "90:dd:5d:12:34:56",
+                    "Hw": "Apple, Inc.",
+                    "Date": "2026-08-29 09:15:00",
+                    "Known": 0,
+                    "Now": 0,
+                },
+            ],
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["data"]["created"], 2)
+        imported = Device.objects.get(mac="b0:be:76:12:34:56")
+        self.assertEqual(imported.name, "Living Room TV")
+        self.assertEqual(imported.hostname, "living-room-tv.local")
+        self.assertEqual(imported.hostname_source, Device.IdentitySource.IMPORTED)
+        self.assertEqual(imported.vendor, "TP-Link Systems Inc.")
+        self.assertEqual(imported.vendor_source, Device.IdentitySource.IMPORTED)
+        self.assertTrue(imported.known)
+        self.assertTrue(imported.online)
+        self.assertEqual(imported.status, Device.Status.ONLINE)
+        offline = Device.objects.get(mac="90:dd:5d:12:34:56")
+        self.assertFalse(offline.known)
+        self.assertFalse(offline.online)
+        self.assertEqual(offline.status, Device.Status.OFFLINE)
+
+    def test_watchyourlan_inventory_import_updates_existing_device_by_mac(self):
+        response = self.client.post(
+            "/api/v1/devices/import/watchyourlan/",
+            [
+                {
+                    "Name": "Migrated laptop",
+                    "DNS": "migrated-laptop.local",
+                    "IP": "192.168.1.40",
+                    "Mac": "aa:aa:aa:aa:aa:aa",
+                    "Hw": "Example vendor",
+                    "Date": "2026-08-29 11:00:00",
+                    "Known": 1,
+                    "Now": 1,
+                }
+            ],
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["data"]["updated"], 1)
+        self.device.refresh_from_db()
+        self.assertEqual(self.device.name, "Migrated laptop")
+        self.assertEqual(self.device.ip, "192.168.1.40")
+        self.assertEqual(self.device.hostname, "migrated-laptop.local")
+        self.assertTrue(self.device.known)
+
+    def test_watchyourlan_inventory_import_rejects_other_json_shapes(self):
+        response = self.client.post(
+            "/api/v1/devices/import/watchyourlan/",
+            {"devices": []},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("WatchYourLAN", response.data["detail"])
+
+        response = self.client.post(
+            "/api/v1/devices/import/watchyourlan/",
+            [
+                {
+                    "name": "LanGuard device",
+                    "ip": "192.168.1.60",
+                    "mac": "90:dd:5d:12:34:60",
+                }
+            ],
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("WatchYourLAN", response.data["detail"])
+
+    def test_watchyourlan_inventory_import_requires_admin(self):
+        regular_user = User.objects.create_user(username="viewer", password="password")
+        regular_client = APIClient()
+        regular_client.force_authenticate(regular_user)
+
+        response = regular_client.post(
+            "/api/v1/devices/import/watchyourlan/",
+            [],
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 403)
+
     def test_device_inventory_import_restores_comments_and_acknowledges_current_risk(self):
         response = self.client.post(
             "/api/v1/devices/import/",

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -21,6 +21,7 @@ from .views import (
     health_status,
     home_map_layout,
     import_devices,
+    import_watchyourlan_devices,
     maintenance_cleanup,
     test_notification_channel,
     users,
@@ -52,6 +53,11 @@ urlpatterns = [
     path("notifications/", notifications, name="notifications"),
     path("devices/export/", export_devices, name="export_devices"),
     path("devices/import/", import_devices, name="import_devices"),
+    path(
+        "devices/import/watchyourlan/",
+        import_watchyourlan_devices,
+        name="import_watchyourlan_devices",
+    ),
     path("export-db/", export_db, name="export_db"),
     path("import-db/", import_db, name="import_db"),
 ]

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -441,6 +441,70 @@ def inventory_devices_from_payload(payload):
     return devices
 
 
+def watchyourlan_devices_from_payload(payload):
+    if isinstance(payload, list):
+        hosts = payload
+    elif isinstance(payload, dict) and isinstance(payload.get("data"), list):
+        hosts = payload["data"]
+    else:
+        raise ValidationError(
+            {
+                "detail": (
+                    "Choose a WatchYourLAN JSON file downloaded from the /api/all endpoint."
+                )
+            }
+        )
+
+    if hosts and not any(
+        isinstance(host, dict) and ("Mac" in host or "IP" in host)
+        for host in hosts
+    ):
+        raise ValidationError(
+            {
+                "detail": (
+                    "The selected file does not contain WatchYourLAN /api/all records."
+                )
+            }
+        )
+
+    devices = []
+    for host in hosts:
+        if not isinstance(host, dict):
+            devices.append(host)
+            continue
+
+        name = host.get("Name")
+        hostname = host.get("DNS")
+        ip = host.get("IP")
+        mac = host.get("Mac")
+        vendor = host.get("Hw")
+        known = host.get("Known", 0)
+        online = parse_inventory_bool(host.get("Now", 0))
+        last_seen = host.get("Date")
+
+        devices.append(
+            {
+                "name": name or hostname or "Device",
+                "hostname": hostname or "",
+                "hostname_source": Device.IdentitySource.IMPORTED if hostname else "",
+                "ip": ip,
+                "mac": mac,
+                "vendor": vendor or "",
+                "vendor_source": Device.IdentitySource.IMPORTED if vendor else "",
+                "known": parse_inventory_bool(known),
+                "status": Device.Status.ONLINE if online else Device.Status.OFFLINE,
+                "first_seen": last_seen,
+                "last_seen": last_seen,
+            }
+        )
+
+    return {
+        "format": INVENTORY_FORMAT,
+        "version": 1,
+        "devices": devices,
+    }
+
+
 def import_inventory_devices(payload):
     imported_devices = inventory_devices_from_payload(payload)
     created = 0
@@ -622,7 +686,7 @@ def inventory_export_response():
     )
 
 
-def inventory_import_response(payload):
+def inventory_import_response(payload, source="LanGuard"):
     try:
         result = import_inventory_devices(payload)
     except ValidationError:
@@ -649,7 +713,7 @@ def inventory_import_response(payload):
         {
             "status": "OK",
             "info": (
-                f"Imported {result['created']} new devices and updated "
+                f"Imported {result['created']} new devices from {source} and updated "
                 f"{result['updated']} existing devices."
             ),
             "data": result,
@@ -1435,3 +1499,14 @@ def export_devices(request):
 @permission_classes([permissions.IsAdminUser])
 def import_devices(request):
     return inventory_import_response(request.data)
+
+
+@extend_schema(
+    request=OpenApiTypes.OBJECT,
+    responses=OpenApiTypes.OBJECT,
+)
+@api_view(["POST"])
+@permission_classes([permissions.IsAdminUser])
+def import_watchyourlan_devices(request):
+    payload = watchyourlan_devices_from_payload(request.data)
+    return inventory_import_response(payload, source="WatchYourLAN")

--- a/frontend/app/page.jsx
+++ b/frontend/app/page.jsx
@@ -2981,6 +2981,7 @@ function SettingsPage({ onSaved }) {
   const [testingChannel, setTestingChannel] = useState('');
   const [exporting, setExporting] = useState(false);
   const [importing, setImporting] = useState(false);
+  const [importingWatchYourLan, setImportingWatchYourLan] = useState(false);
   const [cleanupDays, setCleanupDays] = useState(90);
   const [cleanupTarget, setCleanupTarget] = useState(null);
   const [cleaningActivity, setCleaningActivity] = useState('');
@@ -3140,6 +3141,38 @@ function SettingsPage({ onSaved }) {
       showErrorNotification('Could not import inventory', message);
     } finally {
       setImporting(false);
+    }
+  }
+
+  async function importWatchYourLanFile(file) {
+    if (!file) {
+      return;
+    }
+
+    setImportingWatchYourLan(true);
+    setError('');
+    try {
+      const text = await file.text();
+      const payload = JSON.parse(text);
+      const result = await apiRequest('devices/import/watchyourlan/', {
+        method: 'POST',
+        body: payload,
+      });
+      await onSaved({});
+      const summary = result.data || {};
+      showSuccessNotification(
+        'WatchYourLAN migration complete',
+        `Created ${summary.created || 0}, updated ${summary.updated || 0}, skipped ${summary.skipped || 0}.`
+      );
+    } catch (err) {
+      const message =
+        err instanceof SyntaxError
+          ? 'Choose a valid JSON file downloaded from the WatchYourLAN /api/all endpoint.'
+          : err.message;
+      setError(message);
+      showErrorNotification('Could not import WatchYourLAN devices', message);
+    } finally {
+      setImportingWatchYourLan(false);
     }
   }
 
@@ -3482,6 +3515,29 @@ function SettingsPage({ onSaved }) {
               )}
             </FileButton>
           </Group>
+        </Group>
+
+        <Divider />
+
+        <Group justify="space-between" align="flex-start">
+          <Box>
+            <Text fw={700}>WatchYourLAN migration</Text>
+            <Text size="sm" c="dimmed">
+              Import devices from the JSON returned by the WatchYourLAN <code>/api/all</code> endpoint.
+            </Text>
+          </Box>
+          <FileButton onChange={importWatchYourLanFile} accept="application/json,.json">
+            {(props) => (
+              <Button
+                {...props}
+                variant="light"
+                leftSection={<IconUpload size={18} />}
+                loading={importingWatchYourLan}
+              >
+                Import from WatchYourLAN
+              </Button>
+            )}
+          </FileButton>
         </Group>
 
         <Divider />


### PR DESCRIPTION
## Summary

- add an admin-only Docker import path for WatchYourLAN `/api/all` JSON exports
- map device identity, known state, online state, and last-seen data into the existing LanGuard inventory importer
- add a dedicated migration action and completion feedback in Docker Settings
- document the migration workflow and limitations in the README and changelog

## Verification

- backend: 200 tests passed
- backend migrations: no pending changes
- OpenAPI schema validation passed
- frontend lint passed
- frontend production build passed

No version bump or release publishing is included.