### PR TITLE
Add routable Docker pages and proper 404 handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Added dedicated Docker routes for Dashboard, Home Map, Events, Scan history, Notifications, and Settings with working refresh and browser Back/Forward navigation.
+- Added a dedicated Not Found page and proper HTTP 404 responses for unknown Docker routes.
+
 ## 1.8.1 - 2026-08-30
 
 - **Docker/web only:** Fixed backend health checks being rejected when custom `ALLOWED_HOSTS` omitted the internal loopback address, which could prevent dependent containers from starting or staying available.

--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -19,9 +19,19 @@
 
 	handle {
 		root * /srv/frontend
+		@root path /
+		rewrite @root /index.html
 		@device_page path_regexp device_page ^/devices/[0-9]+/?$
 		rewrite @device_page /devices.html
-		try_files {path} /index.html
+		@trailing_slash path_regexp trailing_slash ^(.+)/$
+		rewrite @trailing_slash {re.trailing_slash.1}
+		try_files {path} {path}.html =404
+		file_server
+	}
+
+	handle_errors {
+		root * /srv/frontend
+		rewrite * /404.html
 		file_server
 	}
 }

--- a/frontend/app/dashboard/page.jsx
+++ b/frontend/app/dashboard/page.jsx
@@ -1,0 +1,5 @@
+import { LanGuardApplication } from '../page';
+
+export default function DashboardPage() {
+  return <LanGuardApplication initialView="dashboard" />;
+}

--- a/frontend/app/events/page.jsx
+++ b/frontend/app/events/page.jsx
@@ -1,0 +1,5 @@
+import { LanGuardApplication } from '../page';
+
+export default function EventsPage() {
+  return <LanGuardApplication initialView="events" />;
+}

--- a/frontend/app/home-map/page.jsx
+++ b/frontend/app/home-map/page.jsx
@@ -1,0 +1,5 @@
+import { LanGuardApplication } from '../page';
+
+export default function HomeMapPage() {
+  return <LanGuardApplication initialView="home-map" />;
+}

--- a/frontend/app/not-found.jsx
+++ b/frontend/app/not-found.jsx
@@ -49,7 +49,7 @@ export default function NotFound() {
           <Group justify="center">
             <Button
               component="a"
-              href="/"
+              href="/dashboard"
               size="md"
               leftSection={<IconArrowLeft size={18} />}
             >

--- a/frontend/app/notifications/page.jsx
+++ b/frontend/app/notifications/page.jsx
@@ -1,0 +1,5 @@
+import { LanGuardApplication } from '../page';
+
+export default function NotificationsPage() {
+  return <LanGuardApplication initialView="notifications" />;
+}

--- a/frontend/app/page.jsx
+++ b/frontend/app/page.jsx
@@ -4167,6 +4167,33 @@ function NotificationsPage({
 
 const activityPageLimit = 500;
 const dashboardStateStorageKey = 'languard_dashboard_navigation_state';
+const mainViewPaths = {
+  dashboard: '/dashboard',
+  'home-map': '/home-map',
+  events: '/events',
+  history: '/scan-history',
+  notifications: '/notifications',
+  settings: '/settings',
+};
+
+function mainViewPath(view) {
+  return mainViewPaths[view] || mainViewPaths.dashboard;
+}
+
+function mainViewFromPath(pathname) {
+  const normalizedPath = pathname.replace(/\/+$/, '') || '/';
+  if (normalizedPath === '/') {
+    return 'dashboard';
+  }
+  return (
+    Object.entries(mainViewPaths).find(([, path]) => path === normalizedPath)?.[0]
+    || 'dashboard'
+  );
+}
+
+function deviceIdFromPath(pathname) {
+  return pathname.match(/^\/devices\/(\d+)\/?$/)?.[1] || '';
+}
 
 function activityRecordLabel(pagination, loadedCount) {
   const total = pagination?.count ?? loadedCount;
@@ -4194,7 +4221,13 @@ function appendUniqueById(current, incoming) {
   ];
 }
 
-function Dashboard({ user, onLogout, onUserUpdated, initialDeviceId = null }) {
+function Dashboard({
+  user,
+  onLogout,
+  onUserUpdated,
+  initialDeviceId = null,
+  initialView = 'dashboard',
+}) {
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState('');
@@ -4229,7 +4262,7 @@ function Dashboard({ user, onLogout, onUserUpdated, initialDeviceId = null }) {
   const [deviceStatus, setDeviceStatus] = useState('');
   const [firstSeenPeriod, setFirstSeenPeriod] = useState('');
   const [inventoryView, setInventoryView] = useState('table');
-  const [mainView, setMainView] = useState('dashboard');
+  const [mainView, setMainView] = useState(initialView);
   const [deviceOrdering, setDeviceOrdering] = useState('');
   const [eventType, setEventType] = useState('');
   const [devicePageId, setDevicePageId] = useState(
@@ -4290,32 +4323,55 @@ function Dashboard({ user, onLogout, onUserUpdated, initialDeviceId = null }) {
     );
   }
 
+  function storeCurrentHistoryState() {
+    window.history.replaceState(
+      {
+        ...window.history.state,
+        languardMainView: mainView,
+        scrollY: window.scrollY,
+        deviceListScrollTop: deviceListRef.current?.scrollTop || 0,
+      },
+      '',
+      window.location.href
+    );
+  }
+
   function openDevicePage(device) {
     if (!device?.id) {
       return;
     }
     storeDashboardNavigationState();
+    storeCurrentHistoryState();
     window.history.pushState({ languardDevicePage: true }, '', `/devices/${device.id}`);
     setDevicePageId(String(device.id));
     window.setTimeout(() => window.scrollTo({ top: 0 }), 0);
   }
 
   function navigateToView(view) {
+    const targetPath = mainViewPath(view);
     if (devicePageId) {
       storeDashboardNavigationState({ mainView: view, scrollY: 0 });
-      window.history.pushState({}, '', '/');
+      window.history.pushState({ languardMainView: view, scrollY: 0 }, '', targetPath);
       setDevicePageId('');
       setMainView(view);
+      window.setTimeout(() => window.scrollTo({ top: 0 }), 0);
       return;
     }
+    if (mainView === view && window.location.pathname === targetPath) {
+      return;
+    }
+    storeCurrentHistoryState();
+    window.history.pushState({ languardMainView: view, scrollY: 0 }, '', targetPath);
     setMainView(view);
+    window.setTimeout(() => window.scrollTo({ top: 0 }), 0);
   }
 
   function returnFromDevicePage() {
     if (window.history.state?.languardDevicePage) {
       window.history.back();
     } else {
-      window.history.replaceState({}, '', '/');
+      const targetPath = mainViewPath(mainView);
+      window.history.replaceState({ languardMainView: mainView }, '', targetPath);
       setDevicePageId('');
     }
   }
@@ -4324,13 +4380,29 @@ function Dashboard({ user, onLogout, onUserUpdated, initialDeviceId = null }) {
     const previousScrollRestoration = window.history.scrollRestoration;
     window.history.scrollRestoration = 'manual';
 
-    function deviceIdFromPath() {
-      return window.location.pathname.match(/^\/devices\/(\d+)\/?$/)?.[1] || '';
+    const initialPathDeviceId = deviceIdFromPath(window.location.pathname);
+    const pathView = mainViewFromPath(window.location.pathname);
+    setDevicePageId((current) => current || initialPathDeviceId);
+    if (!initialPathDeviceId) {
+      setMainView(pathView);
+      window.history.replaceState(
+        { ...window.history.state, languardMainView: pathView },
+        '',
+        mainViewPath(pathView)
+      );
     }
 
-    setDevicePageId((current) => current || deviceIdFromPath());
-    function handlePopState() {
-      setDevicePageId(deviceIdFromPath());
+    function handlePopState(event) {
+      const nextDeviceId = deviceIdFromPath(window.location.pathname);
+      setDevicePageId(nextDeviceId);
+      if (!nextDeviceId) {
+        setMainView(mainViewFromPath(window.location.pathname));
+        pendingDashboardScrollRef.current = Math.max(Number(event.state?.scrollY) || 0, 0);
+        pendingDeviceListScrollRef.current = Math.max(
+          Number(event.state?.deviceListScrollTop) || 0,
+          0
+        );
+      }
     }
     window.addEventListener('popstate', handlePopState);
     return () => {
@@ -4570,7 +4642,7 @@ function Dashboard({ user, onLogout, onUserUpdated, initialDeviceId = null }) {
       setDeviceStatus(state.deviceStatus || '');
       setFirstSeenPeriod(state.firstSeenPeriod || '');
       setInventoryView(state.inventoryView || 'table');
-      setMainView(state.mainView || 'dashboard');
+      setMainView(mainViewFromPath(window.location.pathname));
       setDeviceOrdering(state.deviceOrdering || '');
       setEventType(state.eventType || '');
       tableStateRef.current = {
@@ -4968,7 +5040,11 @@ function Dashboard({ user, onLogout, onUserUpdated, initialDeviceId = null }) {
               onSaved={async () => loadData({ quiet: true })}
               onDeleted={async () => {
                 storeDashboardNavigationState({ mainView: 'dashboard', scrollY: 0 });
-                window.history.replaceState({}, '', '/');
+                window.history.replaceState(
+                  { languardMainView: 'dashboard' },
+                  '',
+                  mainViewPath('dashboard')
+                );
                 setDevicePageId('');
                 setMainView('dashboard');
               }}
@@ -5358,7 +5434,10 @@ function Dashboard({ user, onLogout, onUserUpdated, initialDeviceId = null }) {
 }
 
 
-export function LanGuardApplication({ initialDeviceId = null }) {
+export function LanGuardApplication({
+  initialDeviceId = null,
+  initialView = 'dashboard',
+}) {
   const [user, setUser] = useState(null);
   const [ready, setReady] = useState(false);
 
@@ -5381,10 +5460,11 @@ export function LanGuardApplication({ initialDeviceId = null }) {
       onLogout={() => setUser(null)}
       onUserUpdated={setUser}
       initialDeviceId={initialDeviceId}
+      initialView={initialView}
     />
   );
 }
 
 export default function Home() {
-  return <LanGuardApplication />;
+  return <LanGuardApplication initialView="dashboard" />;
 }

--- a/frontend/app/scan-history/page.jsx
+++ b/frontend/app/scan-history/page.jsx
@@ -1,0 +1,5 @@
+import { LanGuardApplication } from '../page';
+
+export default function ScanHistoryPage() {
+  return <LanGuardApplication initialView="history" />;
+}

--- a/frontend/app/settings/page.jsx
+++ b/frontend/app/settings/page.jsx
@@ -1,0 +1,5 @@
+import { LanGuardApplication } from '../page';
+
+export default function SettingsPage() {
+  return <LanGuardApplication initialView="settings" />;
+}


### PR DESCRIPTION
## Summary

- add dedicated URLs for Dashboard, Home Map, Events, Scan history, Notifications, and Settings
- preserve fast client-side navigation while supporting refresh and browser Back/Forward
- keep runtime device IDs working through the static-export Caddy route
- serve the dedicated Not Found page with a real HTTP 404 for unknown routes
- support trailing slashes for application and device routes

## Verification

- frontend lint passed
- frontend production build passed
- Caddy configuration validation passed
- application routes returned HTTP 200
- `/devices/123` and `/devices/123/` returned HTTP 200
- an unknown route returned the generated 404 page with HTTP 404

No version bump or release is included.