### PR TITLE
Show HomeBox asset IDs in item search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Included HomeBox asset IDs in device-link search results so similarly named inventory items can be distinguished.
+
 ## 1.15.0 - 2026-09-08
 
 - Added device archiving with an Archived filter, manual restore, retained history, and automatic restoration when a scanner rediscovers the device.

--- a/backend/core/homebox.py
+++ b/backend/core/homebox.py
@@ -52,7 +52,14 @@ class HomeBoxClient:
         if not isinstance(items, list):
             raise HomeBoxError("HomeBox returned an unexpected item list.")
         try:
-            results = [{"value": str(UUID(item["id"])), "label": str(item["name"])} for item in items]
+            results = []
+            for item in items:
+                name = str(item["name"])
+                asset_id = str(item.get("assetId") or "").strip()
+                results.append({
+                    "value": str(UUID(item["id"])),
+                    "label": f"{asset_id} · {name}" if asset_id else name,
+                })
         except (KeyError, ValueError, TypeError) as exc:
             raise HomeBoxError("HomeBox returned an invalid item.") from exc
         return {"items": results, "page": page, "has_more": len(items) == 25}

--- a/backend/core/test_homebox.py
+++ b/backend/core/test_homebox.py
@@ -46,13 +46,24 @@ class HomeBoxTests(TestCase):
 
     @patch("core.homebox.requests.get")
     def test_search_and_pagination(self, get):
-        get.return_value = self.response({"items": [{"id": ITEM_ID, "name": "Router"}]})
+        get.return_value = self.response({"items": [
+            {"id": ITEM_ID, "name": "Router", "assetId": "NET-0042"},
+        ]})
         response = self.client.get("/api/v1/integrations/homebox/items/", {"q": "Router", "page": 2})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data["data"]["items"], [{"value": ITEM_ID, "label": "Router"}])
+        self.assertEqual(response.data["data"]["items"], [
+            {"value": ITEM_ID, "label": "NET-0042 · Router"},
+        ])
         self.assertEqual(get.call_args.kwargs["params"], {"q": "Router", "page": 2, "pageSize": 25})
         self.assertFalse(get.call_args.kwargs["allow_redirects"])
         self.assertEqual(get.call_args.kwargs["headers"]["Authorization"], "Bearer secret-key")
+
+    @patch("core.homebox.requests.get")
+    def test_search_uses_name_when_asset_id_is_missing(self, get):
+        get.return_value = self.response({"items": [{"id": ITEM_ID, "name": "Router"}]})
+        response = self.client.get("/api/v1/integrations/homebox/items/")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["data"]["items"], [{"value": ITEM_ID, "label": "Router"}])
 
     @patch("core.homebox.requests.get")
     def test_connection_uses_saved_key(self, get):


### PR DESCRIPTION
## Summary

- include the HomeBox `assetId` before each item name in device-link search results
- retain the existing name-only display when an inventory item has no asset ID
- document the improvement in the changelog

## Verification

- 309 backend tests passed
- changelog validation and tooling tests passed
- Python compilation and git diff validation passed

Related to #134