### PR TITLE
Add HomeBox device link filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Included HomeBox asset IDs in device-link search results so similarly named inventory items can be distinguished.
+- Added a HomeBox link filter for finding devices that are linked or not linked to inventory items.
 
 ## 1.15.0 - 2026-09-08
 

--- a/backend/core/test_homebox.py
+++ b/backend/core/test_homebox.py
@@ -113,6 +113,35 @@ class HomeBoxTests(TestCase):
         self.assertEqual(DeviceSerializer(self.device).data["homebox_link"], "")
         self.assertEqual(self.client.get("/api/v1/integrations/homebox/items/").status_code, 400)
 
+    def test_device_list_filters_by_homebox_link(self):
+        linked = Device.objects.create(
+            mac="00:11:22:33:44:66",
+            ip="192.168.0.11",
+            homebox_item_id=UUID(ITEM_ID),
+        )
+
+        linked_response = self.client.get("/api/v1/device/", {"homebox_linked": "true"})
+        unlinked_response = self.client.get("/api/v1/device/", {"homebox_linked": "false"})
+        invalid_response = self.client.get("/api/v1/device/", {"homebox_linked": "invalid"})
+
+        self.assertEqual(linked_response.status_code, 200)
+        self.assertEqual([item["id"] for item in linked_response.data["data"]], [linked.id])
+        self.assertEqual(unlinked_response.status_code, 200)
+        self.assertEqual([item["id"] for item in unlinked_response.data["data"]], [self.device.id])
+        self.assertEqual(invalid_response.status_code, 400)
+        self.assertIn("homebox_linked", invalid_response.data)
+
+    def test_scan_status_exposes_safe_homebox_state(self):
+        response = self.client.get("/api/v1/scan/status/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.data["integrations"]["homebox"],
+            {"enabled": True, "configured": True},
+        )
+        self.assertNotIn("homebox.example", str(response.data))
+        self.assertNotIn("secret-key", str(response.data))
+
     @patch("core.homebox.requests.get")
     def test_access_control(self, get):
         user = User.objects.create_user("homebox-reader")

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -1904,6 +1904,7 @@ def device(request):
             open_port = request.query_params.get("open_port")
             first_seen = request.query_params.get("first_seen")
             network_ranges = request.query_params.get("network_ranges")
+            homebox_linked = parse_bool_param(request.query_params, "homebox_linked")
 
             if device_status:
                 if device_status not in Device.Status.values:
@@ -1936,6 +1937,8 @@ def device(request):
                 devices = devices.filter(
                     firstseen__gte=first_seen_threshold(first_seen)
                 )
+            if homebox_linked is not None:
+                devices = devices.filter(homebox_item_id__isnull=not homebox_linked)
             devices = filter_devices_by_network_ranges(devices, network_ranges)
 
             payload = paginated_device_payload(request, devices)
@@ -2223,6 +2226,12 @@ def scan_status(request):
                     "configured": bool(
                         app_config.speedtest_tracker_url
                         and app_config.speedtest_tracker_api_token
+                    ),
+                },
+                "homebox": {
+                    "enabled": app_config.homebox_enabled,
+                    "configured": bool(
+                        app_config.homebox_url and app_config.homebox_api_token
                     ),
                 },
             },

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -826,6 +826,15 @@ textarea {
     grid-area: first-seen;
   }
 
+  .devices-content-panel .device-homebox-filter {
+    grid-area: homebox;
+  }
+
+  .devices-content-panel .devices-panel-controls.with-homebox {
+    grid-template-areas: 'status homebox network first-seen search';
+    grid-template-columns: 120px 130px minmax(180px, 1fr) 135px minmax(180px, 1fr);
+  }
+
   .devices-content-panel .device-search {
     grid-area: search;
   }
@@ -1930,6 +1939,16 @@ textarea {
       minmax(120px, 0.8fr);
   }
 
+  .devices-content-panel .devices-panel-controls.with-homebox {
+    grid-template-areas: 'search status homebox network first-seen';
+    grid-template-columns:
+      minmax(135px, 1.1fr)
+      minmax(100px, 0.7fr)
+      minmax(125px, 0.85fr)
+      minmax(155px, 1.2fr)
+      minmax(110px, 0.8fr);
+  }
+
   .devices-content-panel .devices-panel-controls .mantine-Input-input {
     min-height: 34px;
   }
@@ -2013,12 +2032,30 @@ textarea {
       minmax(115px, 0.8fr);
   }
 
+  .devices-content-panel .devices-panel-controls.with-homebox {
+    grid-template-areas: 'search status homebox network first-seen';
+    grid-template-columns:
+      minmax(125px, 1fr)
+      minmax(90px, 0.7fr)
+      minmax(125px, 0.9fr)
+      minmax(145px, 1.2fr)
+      minmax(105px, 0.8fr);
+  }
+
   .devices-content-panel .devices-panel-controls .mantine-Input-input {
     min-height: 34px;
   }
 }
 
 @media (max-width: 560px) {
+  .devices-content-panel .devices-panel-controls.with-homebox {
+    grid-template-areas:
+      'search search'
+      'status homebox'
+      'network first-seen';
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .dashboard-summary-grid,
   .dashboard-summary-grid.with-speedtest {
     grid-template-columns: minmax(0, 1fr);

--- a/frontend/app/page.jsx
+++ b/frontend/app/page.jsx
@@ -230,6 +230,11 @@ const firstSeenPeriodOptions = [
   { value: '30d', label: 'Last 30 days' },
 ];
 
+const homeBoxLinkOptions = [
+  { value: 'linked', label: 'Linked' },
+  { value: 'not-linked', label: 'Not linked' },
+];
+
 const deviceRoleOptions = [
   'device',
   'gateway',
@@ -6048,6 +6053,7 @@ function Dashboard({
   const [selectedDeviceIds, setSelectedDeviceIds] = useState([]);
   const [bulkUpdatingDevices, setBulkUpdatingDevices] = useState(false);
   const [firstSeenPeriod, setFirstSeenPeriod] = useState('');
+  const [homeBoxLinkStatus, setHomeBoxLinkStatus] = useState('');
   const [inventoryView, setInventoryView] = useState('table');
   const [mainView, setMainView] = useState(initialView);
   const [deviceOrdering, setDeviceOrdering] = useState('');
@@ -6074,6 +6080,7 @@ function Dashboard({
     deviceStatus: '',
     networkRangeFilter: [],
     firstSeenPeriod: '',
+    homeBoxLinkStatus: '',
     deviceLimit: 100,
     deviceOffset: 0,
     deviceOrdering: '',
@@ -6122,6 +6129,10 @@ function Dashboard({
   const showDnsActivity = Boolean(
     integrationStatus?.adguard?.enabled && integrationStatus?.adguard?.configured
   );
+  const homeBoxStatusKnown = Boolean(integrationStatus?.homebox);
+  const showHomeBoxFilter = Boolean(
+    integrationStatus?.homebox?.enabled && integrationStatus?.homebox?.configured
+  );
   const showFirstSeen = deviceOrdering === 'firstseen' || deviceOrdering === '-firstseen';
 
   useEffect(() => {
@@ -6163,6 +6174,7 @@ function Dashboard({
         deviceStatus,
         networkRangeFilter,
         firstSeenPeriod,
+        homeBoxLinkStatus,
         inventoryView,
         mainView,
         deviceOrdering,
@@ -6268,11 +6280,18 @@ function Dashboard({
       deviceStatus,
       networkRangeFilter,
       firstSeenPeriod,
+      homeBoxLinkStatus,
       deviceLimit,
       deviceOffset,
       deviceOrdering,
     };
-  }, [search, deviceStatus, networkRangeFilter, firstSeenPeriod, deviceOrdering]);
+  }, [search, deviceStatus, networkRangeFilter, firstSeenPeriod, homeBoxLinkStatus, deviceOrdering]);
+
+  useEffect(() => {
+    if (homeBoxStatusKnown && !showHomeBoxFilter) {
+      setHomeBoxLinkStatus('');
+    }
+  }, [homeBoxStatusKnown, showHomeBoxFilter]);
 
   async function loadData({ quiet = false, notifyOnError = false, refreshIntegrations = false } = {}) {
     if (quiet) {
@@ -6296,6 +6315,9 @@ function Dashboard({
           ? currentTableState.networkRangeFilter.join(',')
           : undefined,
         first_seen: currentTableState.firstSeenPeriod || undefined,
+        homebox_linked: currentTableState.homeBoxLinkStatus
+          ? String(currentTableState.homeBoxLinkStatus === 'linked')
+          : undefined,
         limit: currentTableState.deviceLimit,
         offset: currentTableState.deviceOffset,
         ordering: currentTableState.deviceOrdering || undefined,
@@ -6518,6 +6540,7 @@ function Dashboard({
         Array.isArray(state.networkRangeFilter) ? state.networkRangeFilter : []
       );
       setFirstSeenPeriod(state.firstSeenPeriod || '');
+      setHomeBoxLinkStatus(state.homeBoxLinkStatus || '');
       setInventoryView(state.inventoryView || 'table');
       setMainView(mainViewFromPath(window.location.pathname));
       setDeviceOrdering(state.deviceOrdering || '');
@@ -6530,6 +6553,7 @@ function Dashboard({
           ? state.networkRangeFilter
           : [],
         firstSeenPeriod: state.firstSeenPeriod || '',
+        homeBoxLinkStatus: state.homeBoxLinkStatus || '',
         deviceOrdering: state.deviceOrdering || '',
       };
       pendingDashboardScrollRef.current = Math.max(Number(state.scrollY) || 0, 0);
@@ -6685,7 +6709,7 @@ function Dashboard({
   useEffect(() => {
     const timer = window.setTimeout(() => loadData({ quiet: true }), 250);
     return () => window.clearTimeout(timer);
-  }, [search, deviceStatus, networkRangeFilter, firstSeenPeriod, deviceOrdering]);
+  }, [search, deviceStatus, networkRangeFilter, firstSeenPeriod, homeBoxLinkStatus, deviceOrdering]);
 
   async function runScan() {
     setRefreshing(true);
@@ -7034,7 +7058,7 @@ function Dashboard({
                   onChange={setInventoryView}
                   aria-label="Inventory view"
                 />
-                <Group className="devices-panel-controls">
+                <Group className={`devices-panel-controls ${showHomeBoxFilter ? 'with-homebox' : ''}`}>
                   <Select
                     className="device-status-filter"
                     w={140}
@@ -7070,6 +7094,18 @@ function Dashboard({
                     aria-label="Filter by first seen"
                     onChange={(value) => setFirstSeenPeriod(value || '')}
                   />
+                  {showHomeBoxFilter && (
+                    <Select
+                      className="device-homebox-filter"
+                      w={140}
+                      placeholder="HomeBox"
+                      clearable
+                      data={homeBoxLinkOptions}
+                      value={homeBoxLinkStatus}
+                      aria-label="Filter by HomeBox link"
+                      onChange={(value) => setHomeBoxLinkStatus(value || '')}
+                    />
+                  )}
                   <TextInput
                     className="device-search"
                     w={{ base: 180, sm: 260 }}


### PR DESCRIPTION
## Summary

- add a HomeBox filter for linked and unlinked devices
- apply the filter server-side so it composes with search, status, network, ordering, and pagination
- show the filter only when HomeBox is enabled and configured
- expose only safe HomeBox availability flags through scan status
- keep the filter layout responsive across desktop, tablet, and phone widths

## Verification

- 311 backend tests passed
- frontend production build and lint passed
- changelog validation and tooling tests passed
- Playwright filter behavior and visual checks passed at desktop, tablet, and phone widths
- git diff validation passed

Closes #140