### PR TITLE
Move devices to a dedicated page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Included HomeBox asset IDs in device-link search results so similarly named inventory items can be distinguished.
 - Added a HomeBox link filter for finding devices that are linked or not linked to inventory items.
+- Moved device inventory to a dedicated Devices page and made MAC addresses consistently visible in the device list.
 
 ## 1.15.0 - 2026-09-08
 

--- a/frontend/app/devices/page.jsx
+++ b/frontend/app/devices/page.jsx
@@ -1,5 +1,5 @@
 import { LanGuardApplication } from '../page';
 
 export default function DevicesPage() {
-  return <LanGuardApplication />;
+  return <LanGuardApplication initialView="devices" />;
 }

--- a/frontend/app/page.jsx
+++ b/frontend/app/page.jsx
@@ -190,7 +190,7 @@ function deviceSubtitle(device) {
   const details = [hostname, vendor].filter(Boolean);
 
   if (details.length) {
-    return details.join(' - ');
+    return [mac, ...details].filter(Boolean).join(' - ');
   }
 
   if (isLocallyAdministeredMac(mac)) {
@@ -5835,6 +5835,7 @@ const activityPageLimit = 500;
 const dashboardStateStorageKey = 'languard_dashboard_navigation_state';
 const mainViewPaths = {
   dashboard: '/dashboard',
+  devices: '/devices',
   'home-map': '/home-map',
   events: '/events',
   history: '/scan-history',
@@ -5913,6 +5914,16 @@ function PrimaryNavigation({
         fullWidth
       >
         Dashboard
+      </Button>
+      <Button
+        className="sidebar-nav-button"
+        variant={!devicePageId && mainView === 'devices' ? 'filled' : 'subtle'}
+        justify="flex-start"
+        leftSection={<IconDeviceDesktop size={18} />}
+        onClick={() => navigate('devices')}
+        fullWidth
+      >
+        Devices
       </Button>
       <Button
         className="sidebar-nav-button"
@@ -6906,6 +6917,7 @@ function Dashboard({
               ? 'Device details'
               : {
                   dashboard: 'Dashboard',
+                  devices: 'Devices',
                   'home-map': 'Home Map',
                   events: 'Events',
                   history: 'Scan history',
@@ -6960,14 +6972,14 @@ function Dashboard({
               onSaved={async () => loadData({ quiet: true })}
               onDeleted={async () => {
                 await loadData({ quiet: true });
-                storeDashboardNavigationState({ mainView: 'dashboard', scrollY: 0 });
+                storeDashboardNavigationState({ mainView: 'devices', scrollY: 0 });
                 window.history.replaceState(
-                  { languardMainView: 'dashboard' },
+                  { languardMainView: 'devices' },
                   '',
-                  mainViewPath('dashboard')
+                  mainViewPath('devices')
                 );
                 setDevicePageId('');
-                setMainView('dashboard');
+                setMainView('devices');
               }}
               timeZone={displayTimeZone}
               roomOptions={roomOptions}
@@ -7017,6 +7029,8 @@ function Dashboard({
             <DNSActivityPage timeZone={displayTimeZone} onSelectDevice={openDevicePage} />
           ) : (
             <>
+          {mainView === 'dashboard' && (
+            <>
           <DashboardStatusCards counters={counters} />
 
           <div className={`dashboard-summary-grid ${speedtestTrackerPayload?.integration?.enabled && speedtestTrackerPayload?.integration?.configured ? 'with-speedtest' : ''}`}>
@@ -7043,7 +7057,10 @@ function Dashboard({
             onSelectDevice={openDevicePage}
             timeZone={displayTimeZone}
           />
+            </>
+          )}
 
+          {mainView === 'devices' && (
           <Paper className="content-panel devices-content-panel" radius="md">
             <Stack gap={0}>
               <Group className="devices-panel-header" justify="space-between" p="md">
@@ -7399,6 +7416,7 @@ function Dashboard({
               )}
             </Stack>
           </Paper>
+          )}
 
             </>
           )}


### PR DESCRIPTION
## Summary

- add a dedicated Devices navigation item and `/devices` view between Dashboard and Home Map
- keep the dashboard focused on status, network summaries, recent changes, and devices needing attention
- show the MAC address first in the desktop device subtitle so it remains visible without opening device details
- return to the Devices page after deleting a device
- track detailed per-device port scanning separately in #143

## Verification

- frontend production build and lint passed
- changelog validation and tooling tests passed
- Playwright verified dashboard separation, navigation order, direct `/devices` loading, MAC visibility, and mobile navigation
- desktop and phone screenshots were visually inspected
- git diff validation passed

Closes #139