### PR TITLE
Improve device MAC display

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -759,6 +759,13 @@ textarea {
   white-space: nowrap;
 }
 
+.device-list-mac-value {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .device-list-last-seen {
   min-width: 0;
 }

--- a/frontend/app/page.jsx
+++ b/frontend/app/page.jsx
@@ -186,18 +186,7 @@ function displayDeviceName(device) {
 function deviceSubtitle(device) {
   const hostname = String(device?.hostname || '').trim();
   const vendor = String(device?.vendor || '').trim();
-  const mac = String(device?.mac || '').trim();
-  const details = [hostname, vendor].filter(Boolean);
-
-  if (details.length) {
-    return [mac, ...details].filter(Boolean).join(' - ');
-  }
-
-  if (isLocallyAdministeredMac(mac)) {
-    return `Private/random MAC - ${mac}`;
-  }
-
-  return mac || '-';
+  return [hostname, vendor].filter(Boolean).join(' - ') || '-';
 }
 
 const eventTypeOptions = [
@@ -7313,8 +7302,11 @@ function Dashboard({
                             <DeviceStatusInline device={device} muted />
                           </Box>
                           <Box>
-                            <Text size="xs" c="dimmed">IP</Text>
+                            <Text size="xs" c="dimmed">IP / MAC</Text>
                             <Text size="sm" fw={700} className="mobile-mono-value device-list-ip-value">{device.ip}</Text>
+                            <Text size="xs" c="dimmed" className="mobile-mono-value device-list-mac-value">
+                              {device.mac || '-'}
+                            </Text>
                           </Box>
                           <Box>
                             <Text size="xs" c="dimmed">Room</Text>
@@ -7378,8 +7370,11 @@ function Dashboard({
                         </Group>
                         <SimpleGrid className="device-mobile-details" cols={2} spacing="xs" mt="sm">
                           <Box>
-                            <Text size="xs" c="dimmed">IP</Text>
+                            <Text size="xs" c="dimmed">IP / MAC</Text>
                             <Text size="sm" className="mobile-mono-value">{device.ip}</Text>
+                            <Text size="xs" c="dimmed" className="mobile-mono-value device-list-mac-value">
+                              {device.mac || '-'}
+                            </Text>
                           </Box>
                           <Box>
                             <Text size="xs" c="dimmed">
@@ -7399,10 +7394,6 @@ function Dashboard({
                           <Box className="device-mobile-wide">
                             <Text size="xs" c="dimmed">Role</Text>
                             <Text size="sm">{formatRoleLabel(device.role)}</Text>
-                          </Box>
-                          <Box className="device-mobile-wide">
-                            <Text size="xs" c="dimmed">MAC</Text>
-                            <Text size="sm" className="mobile-mono-value">{device.mac}</Text>
                           </Box>
                           <Box className="device-mobile-wide">
                             <Text size="xs" c="dimmed">Ports</Text>


### PR DESCRIPTION
## Summary

- show the MAC address directly below the IP address in device lists
- rename the field label to `IP / MAC` across desktop, tablet, and mobile layouts
- remove the duplicated MAC address from device subtitles and detail-page headings

## Verification

- `npm run lint`
- `npm run build`
- `git diff --check`