### PR TITLE
Add Wake-on-LAN device action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Included HomeBox asset IDs in device-link search results so similarly named inventory items can be distinguished.
 - Added a HomeBox link filter for finding devices that are linked or not linked to inventory items.
 - Moved device inventory to a dedicated Devices page and made MAC addresses consistently visible in the device list.
+- Added Wake-on-LAN actions to device pages for remotely powering on supported devices.
 
 ## 1.15.0 - 2026-09-08
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ alerts when new devices appear.
 **Monitor**
 
 - Track online and offline state, port changes, and device activity
+- Wake supported devices directly from their device page with Wake-on-LAN
 - Compare completed scans and retain scan, event, and notification history
 - Run scheduled scans after the configured interval
 

--- a/backend/core/test_wake_on_lan.py
+++ b/backend/core/test_wake_on_lan.py
@@ -1,0 +1,141 @@
+from unittest.mock import patch
+
+from django.contrib.auth.models import User
+from django.test import SimpleTestCase, TestCase
+from rest_framework.test import APIClient
+
+from .models import AppSettings, Device, UserAccess
+from .wake_on_lan import magic_packet, send_magic_packet, wake_broadcast_address
+
+
+class WakeOnLanPacketTests(SimpleTestCase):
+    def test_magic_packet_contains_header_and_repeated_mac(self):
+        packet = magic_packet("00:11:22:33:44:55")
+
+        self.assertEqual(packet, b"\xff" * 6 + bytes.fromhex("001122334455") * 16)
+
+    def test_magic_packet_rejects_invalid_mac(self):
+        with self.assertRaisesRegex(ValueError, "valid MAC"):
+            magic_packet("not-a-mac")
+
+    def test_broadcast_uses_most_specific_matching_range(self):
+        result = wake_broadcast_address(
+            "192.168.1.20",
+            ["192.168.0.0/16", "192.168.1.0/24"],
+        )
+
+        self.assertEqual(result, "192.168.1.255")
+
+    def test_broadcast_falls_back_when_device_is_outside_configured_ranges(self):
+        result = wake_broadcast_address("192.168.50.20", ["192.168.1.0/24"])
+
+        self.assertEqual(result, "255.255.255.255")
+
+    @patch("core.wake_on_lan.socket.socket")
+    def test_send_magic_packet_sends_three_udp_broadcasts(self, socket_mock):
+        wake_socket = socket_mock.return_value.__enter__.return_value
+
+        send_magic_packet("00:11:22:33:44:55", "192.168.1.255")
+
+        wake_socket.setsockopt.assert_called_once()
+        self.assertEqual(wake_socket.sendto.call_count, 3)
+        wake_socket.sendto.assert_called_with(
+            b"\xff" * 6 + bytes.fromhex("001122334455") * 16,
+            ("192.168.1.255", 9),
+        )
+
+
+class WakeDeviceApiTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="admin",
+            password="password",
+            is_staff=True,
+        )
+        self.client = APIClient()
+        self.client.force_authenticate(self.user)
+        self.device = Device.objects.create(
+            name="Desktop",
+            ip="192.168.1.20",
+            mac="00:11:22:33:44:55",
+        )
+        AppSettings.objects.create(
+            ip_range="192.168.1.0/24",
+            scan_ranges=["192.168.1.0/24"],
+        )
+
+    @patch("core.views.send_magic_packet")
+    def test_wake_device_sends_packet_to_network_broadcast(self, send_mock):
+        response = self.client.post(
+            "/api/v1/device/wake/",
+            {"id": self.device.id},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 202)
+        send_mock.assert_called_once_with("00:11:22:33:44:55", "192.168.1.255")
+        self.assertEqual(response.data["notification"]["title"], "Wake request sent")
+
+    def test_wake_device_requires_authentication(self):
+        client = APIClient()
+
+        response = client.post(
+            "/api/v1/device/wake/",
+            {"id": self.device.id},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 401)
+
+    def test_wake_device_requires_scan_permission(self):
+        viewer = User.objects.create_user(username="viewer", password="password")
+        UserAccess.objects.create(user=viewer, can_run_scans=False)
+        client = APIClient()
+        client.force_authenticate(viewer)
+
+        response = client.post(
+            "/api/v1/device/wake/",
+            {"id": self.device.id},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_wake_device_rejects_invalid_mac(self):
+        self.device.mac = "invalid"
+        self.device.save(update_fields=["mac"])
+
+        response = self.client.post(
+            "/api/v1/device/wake/",
+            {"id": self.device.id},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("valid MAC", response.data["device"])
+
+    @patch("core.views.send_magic_packet", side_effect=OSError("network unavailable"))
+    def test_wake_device_returns_safe_error_when_send_fails(self, _send_mock):
+        response = self.client.post(
+            "/api/v1/device/wake/",
+            {"id": self.device.id},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.data["notification"]["title"], "Wake request failed")
+        self.assertNotIn("network unavailable", str(response.data))
+
+    @patch("core.views.send_magic_packet")
+    def test_wake_device_does_not_wake_archived_devices(self, send_mock):
+        self.device.archived = True
+        self.device.save(update_fields=["archived"])
+
+        response = self.client.post(
+            "/api/v1/device/wake/",
+            {"id": self.device.id},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 404)
+        send_mock.assert_not_called()

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -15,6 +15,7 @@ from .views import (
     device_availability,
     bulk_update_devices,
     device_web_interface,
+    wake_device,
     events,
     scan_now,
     scan_runs,
@@ -70,6 +71,7 @@ urlpatterns = [
     path("device/availability/", device_availability, name="device-availability"),
     path("devices/bulk-update/", bulk_update_devices, name="bulk-update-devices"),
     path("device/web-interface/", device_web_interface, name="device-web-interface"),
+    path("device/wake/", wake_device, name="wake-device"),
     path("device/dns-activity/", device_dns_activity, name="device-dns-activity"),
     path("dns-activity/", dns_activity, name="dns-activity"),
     path(

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -89,6 +89,7 @@ from .adguard import AdGuardError, sync_adguard_query_log, test_adguard_connecti
 from .speedtest_tracker import SpeedtestTrackerError, latest_speedtest_result
 from .diagnostics import build_diagnostics_report
 from .user_messages import error_response, scan_error_message, success_response
+from .wake_on_lan import send_magic_packet, wake_broadcast_address
 
 LOGGER = logging.getLogger(__name__)
 
@@ -2048,6 +2049,50 @@ def bulk_update_devices(request):
         },
         "Devices updated",
         f"{selected_count} selected device{'s' if selected_count != 1 else ''} marked as {state_label}.",
+        status="OK",
+    )
+
+
+@extend_schema(
+    request=inline_serializer(
+        name="WakeDeviceRequest",
+        fields={"id": serializers.IntegerField(min_value=1)},
+    ),
+    responses=OpenApiTypes.OBJECT,
+)
+@api_view(["POST"])
+@permission_classes([permissions.IsAuthenticated, CanRunScans])
+def wake_device(request):
+    try:
+        device_id = int(request.data.get("id"))
+    except (TypeError, ValueError):
+        raise ValidationError({"id": "A valid device ID is required."})
+    if device_id < 1:
+        raise ValidationError({"id": "A valid device ID is required."})
+
+    device = get_object_or_404(Device, pk=device_id, archived=False)
+    try:
+        broadcast_address = wake_broadcast_address(
+            device.ip,
+            AppSettings.load().effective_scan_ranges,
+        )
+        send_magic_packet(device.mac, broadcast_address)
+    except ValueError as exc:
+        raise ValidationError({"device": str(exc)}) from exc
+    except OSError:
+        LOGGER.exception("Could not send Wake-on-LAN packet for device %s", device.id)
+        return error_response(
+            "Wake request failed",
+            "LanGuard could not send the Wake-on-LAN packet. Check the host network configuration.",
+            response_status=status.HTTP_503_SERVICE_UNAVAILABLE,
+        )
+
+    LOGGER.info("Wake-on-LAN packet sent for device %s", device.id)
+    return success_response(
+        {"id": device.id},
+        "Wake request sent",
+        f"Wake-on-LAN packet sent to {device.name}.",
+        response_status=status.HTTP_202_ACCEPTED,
         status="OK",
     )
 

--- a/backend/core/wake_on_lan.py
+++ b/backend/core/wake_on_lan.py
@@ -1,0 +1,49 @@
+import ipaddress
+import socket
+
+
+DEFAULT_BROADCAST_ADDRESS = "255.255.255.255"
+DEFAULT_PORT = 9
+MAGIC_PACKET_REPETITIONS = 3
+
+
+def magic_packet(mac_address):
+    compact = "".join(character for character in str(mac_address) if character.isalnum())
+    if len(compact) != 12:
+        raise ValueError("The device does not have a valid MAC address.")
+    try:
+        mac_bytes = bytes.fromhex(compact)
+    except ValueError as exc:
+        raise ValueError("The device does not have a valid MAC address.") from exc
+    return b"\xff" * 6 + mac_bytes * 16
+
+
+def wake_broadcast_address(device_ip, network_ranges):
+    try:
+        address = ipaddress.ip_address(device_ip)
+    except ValueError as exc:
+        raise ValueError("The device does not have a valid IPv4 address.") from exc
+    if address.version != 4:
+        raise ValueError("Wake-on-LAN currently requires an IPv4 device address.")
+
+    matching_networks = []
+    for value in network_ranges:
+        try:
+            network = ipaddress.ip_network(value, strict=False)
+        except ValueError:
+            continue
+        if network.version == 4 and network.prefixlen < 31 and address in network:
+            matching_networks.append(network)
+
+    if not matching_networks:
+        return DEFAULT_BROADCAST_ADDRESS
+    network = max(matching_networks, key=lambda candidate: candidate.prefixlen)
+    return str(network.broadcast_address)
+
+
+def send_magic_packet(mac_address, broadcast_address, port=DEFAULT_PORT):
+    packet = magic_packet(mac_address)
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as wake_socket:
+        wake_socket.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+        for _ in range(MAGIC_PACKET_REPETITIONS):
+            wake_socket.sendto(packet, (broadcast_address, port))

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -759,6 +759,13 @@ textarea {
   white-space: nowrap;
 }
 
+.device-list-mac-value {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .device-list-last-seen {
   min-width: 0;
 }

--- a/frontend/app/page.jsx
+++ b/frontend/app/page.jsx
@@ -187,18 +187,7 @@ function displayDeviceName(device) {
 function deviceSubtitle(device) {
   const hostname = String(device?.hostname || '').trim();
   const vendor = String(device?.vendor || '').trim();
-  const mac = String(device?.mac || '').trim();
-  const details = [hostname, vendor].filter(Boolean);
-
-  if (details.length) {
-    return [mac, ...details].filter(Boolean).join(' - ');
-  }
-
-  if (isLocallyAdministeredMac(mac)) {
-    return `Private/random MAC - ${mac}`;
-  }
-
-  return mac || '-';
+  return [hostname, vendor].filter(Boolean).join(' - ') || '-';
 }
 
 const eventTypeOptions = [
@@ -7349,8 +7338,11 @@ function Dashboard({
                             <DeviceStatusInline device={device} muted />
                           </Box>
                           <Box>
-                            <Text size="xs" c="dimmed">IP</Text>
+                            <Text size="xs" c="dimmed">IP / MAC</Text>
                             <Text size="sm" fw={700} className="mobile-mono-value device-list-ip-value">{device.ip}</Text>
+                            <Text size="xs" c="dimmed" className="mobile-mono-value device-list-mac-value">
+                              {device.mac || '-'}
+                            </Text>
                           </Box>
                           <Box>
                             <Text size="xs" c="dimmed">Room</Text>
@@ -7414,8 +7406,11 @@ function Dashboard({
                         </Group>
                         <SimpleGrid className="device-mobile-details" cols={2} spacing="xs" mt="sm">
                           <Box>
-                            <Text size="xs" c="dimmed">IP</Text>
+                            <Text size="xs" c="dimmed">IP / MAC</Text>
                             <Text size="sm" className="mobile-mono-value">{device.ip}</Text>
+                            <Text size="xs" c="dimmed" className="mobile-mono-value device-list-mac-value">
+                              {device.mac || '-'}
+                            </Text>
                           </Box>
                           <Box>
                             <Text size="xs" c="dimmed">
@@ -7435,10 +7430,6 @@ function Dashboard({
                           <Box className="device-mobile-wide">
                             <Text size="xs" c="dimmed">Role</Text>
                             <Text size="sm">{formatRoleLabel(device.role)}</Text>
-                          </Box>
-                          <Box className="device-mobile-wide">
-                            <Text size="xs" c="dimmed">MAC</Text>
-                            <Text size="sm" className="mobile-mono-value">{device.mac}</Text>
                           </Box>
                           <Box className="device-mobile-wide">
                             <Text size="xs" c="dimmed">Ports</Text>

--- a/frontend/app/page.jsx
+++ b/frontend/app/page.jsx
@@ -79,6 +79,7 @@ import {
   IconNetwork,
   IconOutlet,
   IconPlus,
+  IconPower,
   IconPrinter,
   IconPropeller,
   IconQuestionMark,
@@ -2610,6 +2611,7 @@ function DeviceDetailsPage({
   roomOptions,
   dnsActivityEnabled,
   canEditDevices,
+  canRunScans,
 }) {
   const [device, setDevice] = useState(null);
   const [events, setEvents] = useState([]);
@@ -2644,6 +2646,7 @@ function DeviceDetailsPage({
   const [loadingDnsActivity, setLoadingDnsActivity] = useState(false);
   const [loadingMoreDnsActivity, setLoadingMoreDnsActivity] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [waking, setWaking] = useState(false);
   const [editing, setEditing] = useState(false);
   const [error, setError] = useState('');
   const [deleteConfirmOpened, deleteConfirm] = useDisclosure(false);
@@ -2940,6 +2943,24 @@ function DeviceDetailsPage({
     }
   }
 
+  async function wake() {
+    if (!device) {
+      return;
+    }
+    setWaking(true);
+    try {
+      const payload = await apiRequest('device/wake/', {
+        method: 'POST',
+        body: { id: device.id },
+      });
+      showServerNotification(payload);
+    } catch (err) {
+      showErrorNotification(err);
+    } finally {
+      setWaking(false);
+    }
+  }
+
   function cancelEditing() {
     populateForm(device);
     setError('');
@@ -3016,8 +3037,8 @@ function DeviceDetailsPage({
               )}
             </Box>
           </Group>
-          {device && canEditDevices && (
-            editing ? (
+          {device && (canEditDevices || canRunScans) && (
+            editing && canEditDevices ? (
               <Group gap="xs">
                 <Button variant="default" onClick={cancelEditing} disabled={saving}>Cancel</Button>
                 <Button leftSection={<IconDeviceFloppy size={18} />} onClick={save} loading={saving}>
@@ -3026,13 +3047,27 @@ function DeviceDetailsPage({
               </Group>
             ) : (
               <Group gap="xs">
-              <Button variant="default" leftSection={device.archived ? <IconArchiveOff size={18} /> : <IconArchive size={18} />}
-                onClick={archiveConfirm.open}>
-                {device.archived ? 'Restore device' : 'Archive device'}
-              </Button>
-              <Button leftSection={<IconEdit size={18} />} onClick={startEditing}>
-                Edit device
-              </Button>
+              {canRunScans && !device.archived && (
+                <Button
+                  variant="light"
+                  leftSection={<IconPower size={18} />}
+                  loading={waking}
+                  onClick={wake}
+                >
+                  Wake device
+                </Button>
+              )}
+              {canEditDevices && (
+                <>
+                  <Button variant="default" leftSection={device.archived ? <IconArchiveOff size={18} /> : <IconArchive size={18} />}
+                    onClick={archiveConfirm.open}>
+                    {device.archived ? 'Restore device' : 'Archive device'}
+                  </Button>
+                  <Button leftSection={<IconEdit size={18} />} onClick={startEditing}>
+                    Edit device
+                  </Button>
+                </>
+              )}
               </Group>
             )
           )}
@@ -6985,6 +7020,7 @@ function Dashboard({
               roomOptions={roomOptions}
               dnsActivityEnabled={showDnsActivity}
               canEditDevices={canEditDevices}
+              canRunScans={canRunScans}
             />
           ) : mainView === 'home-map' ? (
             <HomeMap


### PR DESCRIPTION
## Summary

- add a Wake device action to Docker device pages
- send repeated Wake-on-LAN magic packets to the matching configured network broadcast address
- enforce authentication and the existing Run scans permission
- document the feature and add it to the unreleased changelog

## Verification

- full Django `core` test suite
- focused Wake-on-LAN backend tests
- OpenAPI schema validation
- `npm run lint`
- `npm run build`
- `git diff --check`

Closes #141