### PR TITLE
Fix Today device filter timezone handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fixed the Today device filter failing when the backend stores naive UTC timestamps.
 - Added IP address change history to device timelines and the central event log.
 - Refactored Docker frontend styling around Mantine theme defaults, scoped modules, and focused layout styles while preserving the existing light, dark, desktop, tablet, and phone appearance.
 - Simplified the Docker Not Found page so the LanGuard logo cleanly replaces the zero in the 404 mark.

--- a/backend/core/tests.py
+++ b/backend/core/tests.py
@@ -4119,6 +4119,29 @@ class ScanApiTests(TestCase):
         self.assertEqual(response.data["pagination"]["count"], 1)
         self.assertEqual(response.data["data"][0]["id"], recent.id)
 
+    def test_device_endpoint_filters_today_in_configured_timezone(self):
+        config = AppSettings.load()
+        config.time_zone = "Asia/Jerusalem"
+        config.save(update_fields=["time_zone"])
+        self.device.firstseen = datetime(2026, 9, 10, 20, 59)
+        self.device.save(update_fields=["firstseen"])
+        today = Device.objects.create(
+            name="Today device",
+            ip="192.168.1.30",
+            mac="bb:bb:bb:bb:bb:bb",
+            firstseen=datetime(2026, 9, 10, 21, 1),
+        )
+
+        with patch(
+            "core.views.timezone.now",
+            return_value=datetime(2026, 9, 10, 22, 30),
+        ):
+            response = self.client.get("/api/v1/device/", {"first_seen": "today"})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["pagination"]["count"], 1)
+        self.assertEqual(response.data["data"][0]["id"], today.id)
+
     def test_device_endpoint_filters_by_configured_network_ranges(self):
         config = AppSettings.load()
         config.ip_range = "192.168.1.0/24"

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -226,8 +226,13 @@ def first_seen_threshold(period):
             app_timezone = ZoneInfo(config.time_zone)
         except ZoneInfoNotFoundError:
             app_timezone = timezone.get_current_timezone()
+        if timezone.is_naive(now):
+            now = timezone.make_aware(now, datetime_timezone.utc)
         local_now = timezone.localtime(now, app_timezone)
-        return local_now.replace(hour=0, minute=0, second=0, microsecond=0)
+        local_midnight = local_now.replace(hour=0, minute=0, second=0, microsecond=0)
+        if not settings.USE_TZ:
+            return timezone.make_naive(local_midnight, datetime_timezone.utc)
+        return local_midnight
     days = 7 if period == "7d" else 30
     return now - timedelta(days=days)
 


### PR DESCRIPTION
## Summary
- fix the Today device filter when Django stores naive UTC timestamps
- calculate local midnight using the configured LanGuard timezone
- add regression coverage for the Asia/Jerusalem timezone

Related to #153.

## Verification
- 325 backend tests